### PR TITLE
TASK: Set minimum typo3 version to 6.2 due to the use of the includeCssF...

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '0.6.0',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.1.0-6.2.99',
+			'typo3' => '6.2.0-6.2.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
Set minimum typo3 version to 6.2 due to the use of the includeCssFiles tag within f:be.container.
