### PR TITLE
[TASK] Review fixes and adaptions

### DIFF
--- a/Classes/TcaDataGenerator/Generator.php
+++ b/Classes/TcaDataGenerator/Generator.php
@@ -161,14 +161,6 @@ class Generator
             }
         }
 
-        // Delete all the pages_language_overlay records on this tree
-        $overlayUids = $recordFinder->findUidsOfStyleguidePagesLanguageOverlay();
-        if (!empty($overlayUids)) {
-            foreach ($overlayUids as $overlayUid) {
-                $commands['pages_language_overlay'][(int)$overlayUid]['delete'] = 1;
-            }
-        }
-
         // Delete all the sys_language demo records
         $languageUids = $recordFinder->findUidsOfDemoLanguages();
         if (!empty($languageUids)) {

--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -62,36 +62,6 @@ class RecordFinder
     }
 
     /**
-     * Returns a uid list of existing styleguide demo pages_language_overlays.
-     * These are pages_language_overlays tx_styleguide_containsdemo set to tca types of 'tx_styleguide'.
-     * This can be multiple pages_language_overlay if "create" button was clicked multiple times without "delete" in between.
-     *
-     * @return array
-     */
-    public function findUidsOfStyleguidePagesLanguageOverlay(): array
-    {
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages_language_overlay');
-        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $rows = $queryBuilder->select('uid')
-            ->from('pages_language_overlay')
-            ->where(
-                $queryBuilder->expr()->like(
-                    'tx_styleguide_containsdemo',
-                    $queryBuilder->createNamedParameter('tx_styleguide%', \PDO::PARAM_STR)
-                )
-            )
-            ->execute()
-            ->fetchAll();
-        $uids = [];
-        if (is_array($rows)) {
-            foreach ($rows as $row) {
-                $uids[] = (int)$row['uid'];
-            }
-        }
-        return $uids;
-    }
-
-    /**
      * "Main" tables have a single page they are located on with their possible children.
      * The methods find this page by getting the highest uid of a page where field
      * tx_styleguide_containsdemo is set to given table name.

--- a/Configuration/TCA/Overrides/sys_language.php
+++ b/Configuration/TCA/Overrides/sys_language.php
@@ -5,7 +5,7 @@ call_user_func(function () {
     // Add a field to sys_language table to identify styleguide demo sys_language`s.
     // Field is handled by DataHandler and is not needed to be shown in BE, so it is of type "passthrough"
     $additionalColumns = [
-        'tx_styleguide_isdemolanguage' => [
+        'tx_styleguide_isdemorecord' => [
             'config' => [
                 'type' => 'passthrough',
             ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,7 +7,7 @@ CREATE TABLE pages_language_overlay (
 );
 
 CREATE TABLE sys_language (
-	tx_styleguide_isdemolanguage tinyint(1) unsigned DEFAULT '0' NOT NULL
+	tx_styleguide_isdemorecord tinyint(1) unsigned DEFAULT '0' NOT NULL
 );
 
 CREATE TABLE be_groups (


### PR DESCRIPTION
The pages_language_overlay part of delete action is unnecessary.
This means the recordfinder function for the overlays is also unneeded.