### PR TITLE
[BUGFIX] allow multi extension permissions

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -56,20 +56,18 @@ if (TYPO3_MODE === 'BE') {
     );
 
     // Register some custom permission options shown in BE group access lists
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'] = [
-        'tx_styleguide_custom' => [
-            'header' => 'Custom styleguide permissions',
-                'items' => [
-                    'key1' => [
-                        'Option 1',
-                        // Icon has been registered above
-                        'tcarecords-tx_styleguide_forms-default',
-                        'Description 1',
-                    ],
-                'key2' => [
-                    'Option 2'
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_styleguide_custom'] = [
+        'header' => 'Custom styleguide permissions',
+            'items' => [
+                'key1' => [
+                    'Option 1',
+                    // Icon has been registered above
+                    'tcarecords-tx_styleguide_forms-default',
+                    'Description 1',
                 ],
-            ]
+            'key2' => [
+                'Option 2'
+            ],
         ]
     ];
 


### PR DESCRIPTION
This fixes the problem, that styleguide removes permissions from all other extensions due to overwriting the whole array