### PR TITLE
[FEATURE] TCA record for inline 1n with a not translatable child

### DIFF
--- a/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
@@ -1,0 +1,154 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Form engine - inline 1:n foreign field without l10n in child',
+        'label' => 'uid',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'iconfile' => 'EXT:styleguide/Resources/Public/Icons/tx_styleguide.svg',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+        ],
+    ],
+
+
+    'columns' => [
+        'hidden' => [
+            'exclude' => 1,
+            'config' => [
+                'type' => 'check',
+                'items' => [
+                    '1' => [
+                        '0' => 'Disable',
+                    ],
+                ],
+            ],
+        ],
+        'starttime' => [
+            'exclude' => 1,
+            'label' => 'Publish Date',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+                'default' => '0'
+            ],
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly'
+        ],
+        'endtime' => [
+            'exclude' => 1,
+            'label' => 'Expiration Date',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+                'default' => '0',
+                'range' => [
+                    'upper' => mktime(0, 0, 0, 12, 31, 2020)
+                ]
+            ],
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly'
+        ],
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'special' => 'languages',
+                'items' => [
+                    [
+                        'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                        -1,
+                        'flags-multiple'
+                    ],
+                ],
+                'default' => 0,
+            ]
+        ],
+        'l10n_parent' => [
+            'exclude' => true,
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        '',
+                        0
+                    ]
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nnol10n',
+                'foreign_table_where' => 'AND tx_styleguide_inline_1nnol10n.pid=###CURRENT_PID### AND tx_styleguide_inline_1nnol10n.sys_language_uid IN (-1,0)',
+                'default' => 0
+            ]
+        ],
+        'l10n_source' => [
+            'exclude' => true,
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation source',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        '',
+                        0
+                    ]
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nnol10n',
+                'foreign_table_where' => 'AND tx_styleguide_inline_1nnol10n.pid=###CURRENT_PID### AND tx_styleguide_inline_1nnol10n.uid!=###THIS_UID###',
+                'default' => 0
+            ]
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => ''
+            ]
+        ],
+
+        'inline_1' => [
+            'exclude' => 1,
+            'l10n_mode' => 'exclude',
+            'label' => 'inline_1',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_styleguide_inline_1nnol10n_child',
+                'foreign_field' => 'parentid',
+                'foreign_table_field' => 'parenttable',
+            ],
+            'maxitems' => 1,
+        ],
+
+
+    ],
+
+
+    'types' => [
+        '0' => [
+            'showitem' => '
+                inline_1,
+                --div--;meta,
+                    disable, starttime, endtime, sys_language_uid, l10n_parent, l10n_source,
+
+            ',
+        ],
+    ],
+
+
+];

--- a/Configuration/TCA/tx_styleguide_inline_1nnol10n_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nnol10n_child.php
@@ -1,0 +1,58 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'Form engine - inline 1:n foreign field child without l10n',
+        'label' => 'input_1',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'iconfile' => 'EXT:styleguide/Resources/Public/Icons/tx_styleguide.svg',
+        'enablecolumns' => [
+            'disabled' => 'disable',
+        ],
+    ],
+
+
+    'columns' => [
+
+        'disable' => [
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.disable',
+            'config' => [
+                'type' => 'check'
+            ]
+        ],
+
+        'parentid' => [
+            'config' => [
+                'type' => 'passthrough',
+            ]
+        ],
+        'parenttable' => [
+            'config' => [
+                'type' => 'passthrough',
+            ]
+        ],
+        'input_1' => [
+            'l10n_mode' => 'prefixLangTitle',
+            'label' => 'input_1',
+            'config' => [
+                'type' => 'input',
+                'size' => '30',
+            ],
+        ],
+
+
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;General, input_1,
+                --div--;meta, disable, sys_language_uid, l10n_parent, l10n_source,
+            ',
+        ],
+    ],
+
+
+];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -92,6 +92,9 @@ if (TYPO3_MODE === 'BE') {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1n');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1n_child');
 
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1nnol10n');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1nnol10n_child');
+
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1n1n');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1n1n_child');
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_inline_1n1n_childchild');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -854,6 +854,74 @@ CREATE TABLE tx_styleguide_inline_1n_child (
 	group_db_1 text,
 	select_tree_1 text,
 
+	PRIMARY KEY (uid),
+	KEY parent (pid)
+);
+
+CREATE TABLE tx_styleguide_inline_1nnol10n (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	cruser_id int(11) DEFAULT '0' NOT NULL,
+	deleted tinyint(4) DEFAULT '0' NOT NULL,
+	hidden tinyint(4) DEFAULT '0' NOT NULL,
+	starttime int(11) DEFAULT '0' NOT NULL,
+	endtime int(11) DEFAULT '0' NOT NULL,
+	sorting int(11) DEFAULT '0' NOT NULL,
+
+	sys_language_uid int(11) DEFAULT '0' NOT NULL,
+	l10n_parent int(11) DEFAULT '0' NOT NULL,
+	l10n_source int(11) DEFAULT '0' NOT NULL,
+	l10n_diffsource mediumtext,
+
+	t3ver_oid int(11) DEFAULT '0' NOT NULL,
+	t3ver_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
+	t3ver_label varchar(255) DEFAULT '' NOT NULL,
+	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_stage int(11) DEFAULT '0' NOT NULL,
+	t3ver_count int(11) DEFAULT '0' NOT NULL,
+	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
+	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
+	t3_origuid int(11) DEFAULT '0' NOT NULL,
+
+	inline_1 int(11) DEFAULT '0' NOT NULL,
+
+	PRIMARY KEY (uid),
+	KEY parent (pid)
+);
+
+
+CREATE TABLE tx_styleguide_inline_1nnol10n_child (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	cruser_id int(11) DEFAULT '0' NOT NULL,
+	deleted tinyint(4) DEFAULT '0' NOT NULL,
+	disable tinyint(4) DEFAULT '0' NOT NULL,
+	starttime int(11) DEFAULT '0' NOT NULL,
+	endtime int(11) DEFAULT '0' NOT NULL,
+	sorting int(11) DEFAULT '0' NOT NULL,
+
+	t3ver_oid int(11) DEFAULT '0' NOT NULL,
+	t3ver_id int(11) DEFAULT '0' NOT NULL,
+	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
+	t3ver_label varchar(30) DEFAULT '' NOT NULL,
+	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
+	t3ver_count int(11) DEFAULT '0' NOT NULL,
+	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
+	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
+	t3_origuid int(11) DEFAULT '0' NOT NULL,
+
+	parentid int(11) DEFAULT '0' NOT NULL,
+	parenttable text,
+
+	input_1 text,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid)


### PR DESCRIPTION
The not translatable status is also marked with `'l10n_mode' => 'exclude'` in the parent records TCA.