### PR TITLE
[BUGFIX] Use correct class for table

### DIFF
--- a/Resources/Private/Templates/Styleguide/Tables.html
+++ b/Resources/Private/Templates/Styleguide/Tables.html
@@ -74,7 +74,7 @@
 
 	<sg:code language="html">
 	<div class="table-fit">
-		<table class="t3-table">
+		<table class="table">
 			<thead>
 				<tr>
 					<th>Head 1</th>


### PR DESCRIPTION
Instead of using `t3-table` use the class `table`