### PR TITLE
[TASK] Set l10n display setting to `defaultAsReadonly` for select

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -142,6 +142,8 @@ return [
         'select_single_2' => [
             'exclude' => 1,
             'label' => 'select_single_2 itemsProcFunc',
+            'l10n_mode' => 'exclude',
+            'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',


### PR DESCRIPTION
This allows testing the behaviour of this field in a translated element.

---

The main goal of this change is to be able to test this ticket: https://forge.typo3.org/issues/82843