### PR TITLE
[FEATURE] Render deprecated icons

### DIFF
--- a/Classes/Controller/StyleguideController.php
+++ b/Classes/Controller/StyleguideController.php
@@ -177,15 +177,18 @@ class StyleguideController extends ActionController
     {
         $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
         $allIcons = $iconRegistry->getAllRegisteredIconIdentifiers();
-        $this->view->assign('allIcons', $allIcons);
-
-        $overlays = [];
-        foreach ($allIcons as $key) {
-            if (strpos($key, 'overlay') === 0) {
-                $overlays[] = $key;
+        $overlays = array_filter(
+            $allIcons,
+            function ($key) {
+                return strpos($key, 'overlay') === 0;
             }
-        }
-        $this->view->assign('overlays', $overlays);
+        );
+
+        $this->view->assignMultiple([
+            'allIcons' => $allIcons,
+            'deprecatedIcons' => $iconRegistry->getDeprecatedIcons(),
+            'overlays' => $overlays,
+        ]);
     }
 
     /**

--- a/Resources/Private/Styles/_components/_icon.less
+++ b/Resources/Private/Styles/_components/_icon.less
@@ -4,6 +4,10 @@ div.icon-container {
 	margin-bottom: 20px;
 	height: 100px;
 
+	&.icon-deprecated-container {
+		height: 175px;
+	}
+
 	span.icon-container-icon,
 	span.icon-container-label {
 		display: block;

--- a/Resources/Private/Templates/Styleguide/Icons.html
+++ b/Resources/Private/Templates/Styleguide/Icons.html
@@ -1,5 +1,8 @@
-{namespace sg=TYPO3\CMS\Styleguide\ViewHelpers}
-{namespace core = TYPO3\CMS\Core\ViewHelpers}
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+			xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+			xmlns:sg="http://typo3.org/ns/TYPO3/CMS/Styleguide/ViewHelpers"
+			data-namespace-typo3-fluid="true">
+
 <f:layout name="Default" />
 
 <f:section name="content">
@@ -15,6 +18,7 @@
 		<ul class="nav nav-tabs" role="tablist">
 			<li role="presentation" class="active"><a href="#iconprovider" aria-controls="iconprovider" role="tab" data-toggle="tab">IconProvider</a></li>
 			<li role="presentation"><a href="#all" aria-controls="all" role="tab" data-toggle="tab">All Icons</a></li>
+			<li role="presentation"><a href="#deprecated" aria-controls="deprecated" role="tab" data-toggle="tab">Deprecated Icons</a></li>
 			<li role="presentation"><a href="#overlays" aria-controls="overlays" role="tab" data-toggle="tab">All Overlays</a></li>
 			<li role="presentation"><a href="#examples" aria-controls="examples" role="tab" data-toggle="tab">Examples</a></li>
 		</ul>
@@ -111,6 +115,17 @@
 						<div class="col-md-2 icon-container" data-icon-identifier="{icon}">
 							<span class="icon-container-icon"><core:icon identifier="{icon}" size="large" /></span>
 							<span class="icon-container-label">{icon}</span>
+						</div>
+					</f:for>
+				</div>
+			</div>
+			<div role="tabpanel" class="tab-pane" id="deprecated">
+				<div class="row">
+					<f:for each="{deprecatedIcons}" key="icon" as="alternativeIcon">
+						<div class="col-md-2 icon-container icon-deprecated-container" data-icon-identifier="{icon}">
+							<span class="icon-container-icon"><core:icon identifier="{icon}" size="large" /></span>
+							<span class="icon-container-label"><i class="fa fa-arrow-circle-left"></i> {icon}</span>
+							<span class="icon-container-label"><i class="fa fa-arrow-circle-right"></i> {alternativeIcon}</span>
 						</div>
 					</f:for>
 				</div>

--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -225,6 +225,9 @@ div.icon-container {
   margin-bottom: 20px;
   height: 100px;
 }
+div.icon-container.icon-deprecated-container {
+  height: 175px;
+}
 div.icon-container span.icon-container-icon,
 div.icon-container span.icon-container-label {
   display: block;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/TYPO3/styleguide",
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-watch": "~0.6.1"
   }


### PR DESCRIPTION
Renders deprecated icons of IconRegistry.

Relies on https://review.typo3.org/#/c/55829/ for TYPO3 v9