### PR TITLE
Use DataHandler commands to create and update data for General Handler

### DIFF
--- a/Classes/TcaDataGenerator/TableHandler/AbstractTableHandler.php
+++ b/Classes/TcaDataGenerator/TableHandler/AbstractTableHandler.php
@@ -17,6 +17,7 @@ namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 
 /**
@@ -72,6 +73,50 @@ class AbstractTableHandler
                     break;
             }
         }
+    }
+
+    /**
+     * Creates new record using DataHandler
+     *
+     * @param string $tableName
+     * @param array $fieldValues
+     * @return int
+     */
+    protected function insertRecord(string $tableName, array $fieldValues)
+    {
+        $UidPlaceholder = StringUtility::getUniqueId('NEW');
+
+        $dataMap = [
+            $tableName => [
+                $UidPlaceholder => $fieldValues
+            ]
+        ];
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start($dataMap, []);
+        $dataHandler->process_datamap();
+        return (int)$dataHandler->substNEWwithIDs[$UidPlaceholder];
+    }
+
+
+    /**
+     * Updates a record using datahandler
+     *
+     * @param string $tableName
+     * @param int $uid
+     * @param array $fieldValues
+     * @return int
+     */
+    protected function updateRecord(string $tableName, $uid, array $fieldValues)
+    {
+        $dataMap = [
+            $tableName => [
+                $uid => $fieldValues
+            ]
+        ];
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start($dataMap, []);
+        $dataHandler->process_datamap();
+        return (int)$uid;
     }
 
     /**

--- a/Classes/TcaDataGenerator/TableHandler/General.php
+++ b/Classes/TcaDataGenerator/TableHandler/General.php
@@ -41,7 +41,6 @@ class General extends AbstractTableHandler implements TableHandlerInterface
      * Adds rows
      *
      * @param string $tableName
-     * @return string
      */
     public function handle(string $tableName)
     {
@@ -53,15 +52,11 @@ class General extends AbstractTableHandler implements TableHandlerInterface
         $fieldValues = [
             'pid' => $recordFinder->findPidOfMainTableRecord($tableName),
         ];
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
-        $connection->insert($tableName, $fieldValues);
-        $fieldValues['uid'] = $connection->lastInsertId($tableName);
+        $uid = $this->insertRecord($tableName, $fieldValues);
+        $fieldValues['uid'] = $uid;
+
         $fieldValues = $recordData->generate($tableName, $fieldValues);
-        $connection->update(
-            $tableName,
-            $fieldValues,
-            [ 'uid' => $fieldValues['uid'] ]
-        );
+        $this->updateRecord($tableName, $uid, $fieldValues);
 
         $this->generateTranslatedRecords($tableName, $fieldValues);
     }


### PR DESCRIPTION
Instead of direct sql inserts and updates.
It comes with some performance penalty,
generation time with patch:
1) 21.941178798676
2) 26.553791999817

Without the patch:
1) 20.42106294632
2) 21.038254022598

Note that this patch doesn't replace all direct inserts, but just one in General Table Handler.