### PR TITLE
[TASK] Remove t3ver_label usage

### DIFF
--- a/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
+++ b/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
@@ -72,16 +72,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-
-        't3ver_label' => [
-            'label' => 'version',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
-
         'hidden' => [
             'exclude' => 1,
             'label' => 'disable',


### PR DESCRIPTION
The special handling of this DB field is dropped in TYPO3 core v10

https://review.typo3.org/#/c/59297/