### PR TITLE
Update module registration arguments

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,12 +6,12 @@ if (TYPO3_MODE === 'BE') {
 
     // Register "Styleguide" backend module
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'TYPO3.CMS.styleguide',
+        'styleguide',
         'help',
         'styleguide',
         '',
         [
-            'Styleguide' => 'index, typography, trees, tables, buttons, infobox, avatar, flashMessages, tca, tcaCreate, tcaDelete, debug, helpers, icons, tab, modal'
+            \TYPO3\CMS\Styleguide\Controller\StyleguideController::class => 'index, typography, trees, tables, buttons, infobox, avatar, flashMessages, tca, tcaCreate, tcaDelete, debug, helpers, icons, tab, modal'
         ],
         [
             'access' => 'user,group',


### PR DESCRIPTION
Defining the vendor name yourself (TYPO3.CMS) and using a controller alias ('Styleguide') instead of the FQCN is deprecated since TYPO3 10.4, therefore the module registration must be changed.