### PR TITLE
[BUGFIX] be_sessions.xml fixture from ext:core instead of TF

### DIFF
--- a/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
@@ -44,7 +44,7 @@ class BackendStyleguideEnvironment extends BackendEnvironment
         ],
         'xmlDatabaseFixtures' => [
             'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
-            'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
+            'typo3/sysext/core/Tests/Acceptance/Fixtures/be_sessions.xml',
             'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
         ],
     ];


### PR DESCRIPTION
testing-framework provides a fixture file for backend user
sessions - used to log in users during acceptance tests.

Core v11 however changed db structure of the table:
ses_backupserid is gone. The fixture still tries to set
this, leading to db errors on insert. Solution in
v11 styleguide for to use the fixture provided by
ext:core, instead of the TF version, until the situation
has been solved in testing-framework.