### PR TITLE
Add examples for richtextConfigurations

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -127,7 +127,7 @@ return [
         ],
         'rte_4' => [
             'exclude' => 1,
-            'label' => 'rte_3 eval=null',
+            'label' => 'rte_4 richtextConfiguration=minimal',
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
@@ -136,7 +136,7 @@ return [
         ],
         'rte_5' => [
             'exclude' => 1,
-            'label' => 'rte_3 eval=null',
+            'label' => 'rte_5 richtextConfiguration=full',
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,

--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -275,7 +275,7 @@ return [
         '0' => [
             'showitem' => '
                 --div--;rte,
-                    rte_1, rte_2, rte_3,
+                    rte_1, rte_2, rte_3, rte_4, rte_5,
                 --div--;in inline,
                     rte_inline_1,
                 --div--;in flex,

--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -125,6 +125,24 @@ return [
                 'enableRichtext' => true,
             ],
         ],
+        'rte_4' => [
+            'exclude' => 1,
+            'label' => 'rte_3 eval=null',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => true,
+                'richtextConfiguration' => 'minimal'
+            ],
+        ],
+        'rte_5' => [
+            'exclude' => 1,
+            'label' => 'rte_3 eval=null',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => true,
+                'richtextConfiguration' => 'full'
+            ],
+        ],
 
         'rte_inline_1' => [
             'exclude' => 1,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -153,6 +153,8 @@ CREATE TABLE tx_styleguide_elements_rte (
 	rte_1 text,
 	rte_2 text,
 	rte_3 text,
+	rte_4 text,
+	rte_5 text,
 	rte_inline_1 text,
 	rte_flex_1 text,
 	input_palette_1 text,


### PR DESCRIPTION
Richtext configurations for RTE using "minimal" and "full" configurations

(cherry picked from commit 0bccbfb39a543d67e4976ca9d1fdb09db84e7bcd)