### PR TITLE
Add flex examples checkboxes

### DIFF
--- a/Configuration/TCA/tx_styleguide_flex.php
+++ b/Configuration/TCA/tx_styleguide_flex.php
@@ -139,6 +139,47 @@ return [
                                             </config>
                                         </TCEforms>
                                     </passthrough_2>
+                                    <settings.checkbox_2>
+                                       <TCEforms>
+                                           <label>checkbox_2 one checkbox with label</label>
+                                           <config>
+                                               <type>check</type>
+                                               <items type="array">
+                                                   <numIndex index="0" type="array">
+                                                       <numIndex index="0">foo</numIndex>
+                                                       <numIndex index="1"></numIndex>
+                                                   </numIndex>
+                                               </items>
+                                           </config>
+                                       </TCEforms>
+                                    </settings.checkbox_2>
+                                    <settings.checkbox_12>
+                                       <TCEforms>
+                                           <label>checkbox_12 cols=3</label>
+                                           <config>
+                                               <type>check</type>
+                                               <items type="array">
+                                                   <numIndex index="0" type="array">
+                                                       <numIndex index="0">foo1</numIndex>
+                                                       <numIndex index="1"></numIndex>
+                                                   </numIndex>
+                                                   <numIndex index="1" type="array">
+                                                       <numIndex index="0">foo2</numIndex>
+                                                       <numIndex index="1"></numIndex>
+                                                   </numIndex>
+                                                   <numIndex index="2" type="array">
+                                                       <numIndex index="0">foo3</numIndex>
+                                                       <numIndex index="1"></numIndex>
+                                                   </numIndex>
+                                                   <numIndex index="3" type="array">
+                                                       <numIndex index="0">foo4</numIndex>
+                                                       <numIndex index="1"></numIndex>
+                                                   </numIndex>
+                                               </items>
+                                               <cols>3</cols>
+                                           </config>
+                                       </TCEforms>
+                                    </settings.checkbox_12>
                                 </el>
                             </ROOT>
                         </T3DataStructure>

--- a/Configuration/TCA/tx_styleguide_flex.php
+++ b/Configuration/TCA/tx_styleguide_flex.php
@@ -151,9 +151,9 @@ return [
                                             </config>
                                         </TCEforms>
                                     </passthrough_2>
-                                    <settings.checkbox_2>
+                                    <checkbox_1>
                                        <TCEforms>
-                                           <label>checkbox_2 one checkbox with label</label>
+                                           <label>checkbox_1 one checkbox with label</label>
                                            <config>
                                                <type>check</type>
                                                <items type="array">
@@ -164,10 +164,10 @@ return [
                                                </items>
                                            </config>
                                        </TCEforms>
-                                    </settings.checkbox_2>
-                                    <settings.checkbox_12>
+                                    </checkbox_1>
+                                    <checkbox_2>
                                        <TCEforms>
-                                           <label>checkbox_12 cols=3</label>
+                                           <label>checkbox_2 cols=3</label>
                                            <config>
                                                <type>check</type>
                                                <items type="array">
@@ -191,7 +191,7 @@ return [
                                                <cols>3</cols>
                                            </config>
                                        </TCEforms>
-                                    </settings.checkbox_12>
+                                    </checkbox_2>
                                 </el>
                             </ROOT>
                         </T3DataStructure>


### PR DESCRIPTION
add flex form examples for for checkbox_2 and checkbox_12 from to be used in the tca reference manual

(cherry picked from commit 1c40c72ea7a7c4934547f093acd5074f542e31c2)