### PR TITLE
Improve example for type

### DIFF
--- a/Configuration/TCA/tx_styleguide_type.php
+++ b/Configuration/TCA/tx_styleguide_type.php
@@ -3,7 +3,7 @@
 return [
     'ctrl' => [
         'title' => 'Form engine - type',
-        'label' => 'uid',
+        'label' => 'title',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',

--- a/Configuration/TCA/tx_styleguide_type.php
+++ b/Configuration/TCA/tx_styleguide_type.php
@@ -19,7 +19,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
-        'type' => 'type',
+        'type' => 'record_type',
     ],
 
     'columns' => [
@@ -88,17 +88,31 @@ return [
             ]
         ],
 
-        'type' => [
-            'exclude' => 1,
+        'record_type' => [
             'label' => 'type',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
                     ['type 0', '0'],
+                    ['Type with changed fields', 'withChangedFields'],
+                    ['Type with columnsOverrides', 'withOverriddenColumns'],
                     ['type test', 'test'],
                 ],
             ],
+        ],
+        'title' => [
+            'label' => 'title',
+            'config' => [
+                'type' => 'input',
+            ]
+        ],
+        'color' => [
+            'label' => 'color',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'colorpicker'
+            ]
         ],
 
         'text_1' => [
@@ -113,10 +127,31 @@ return [
 
     'types' => [
         '0' => [
-            'showitem' => 'type, text_1',
+            'showitem' => 'record_type, title, text_1',
+        ],
+        'withChangedFields' => [
+            'showitem' => 'record_type, title, color, text_1',
+        ],
+        'withOverriddenColumns' => [
+            'showitem' => 'record_type, title, color, text_1',
+            'columnsOverrides' => [
+                'color' => [
+                    'config' => [
+                        'renderType' => '',
+                        'readOnly' => true,
+                        'size' => 10,
+                    ],
+                ],
+                'text_1' => [
+                    'config' => [
+                        'renderType' => 't3editor',
+                        'format' => 'html',
+                    ],
+                ],
+            ],
         ],
         'test' => [
-            'showitem' => 'type, text_1',
+            'showitem' => 'record_type, title, text_1',
             'columnsOverrides' => [
                 'text_1' => [
                     'config' => [

--- a/Configuration/TCA/tx_styleguide_type.php
+++ b/Configuration/TCA/tx_styleguide_type.php
@@ -3,7 +3,7 @@
 return [
     'ctrl' => [
         'title' => 'Form engine - type',
-        'label' => 'title',
+        'label' => 'uid',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
@@ -96,19 +96,18 @@ return [
                 'items' => [
                     ['type 0', '0'],
                     ['Type with changed fields', 'withChangedFields'],
-                    ['Type with columnsOverrides', 'withOverriddenColumns'],
-                    ['type test', 'test'],
+                    ['Type with columnsOverrides', 'withColumnsOverrides'],
                 ],
             ],
         ],
-        'title' => [
-            'label' => 'title',
+        'input_1' => [
+            'label' => 'input_1',
             'config' => [
                 'type' => 'input',
             ]
         ],
-        'color' => [
-            'label' => 'color',
+        'input_2' => [
+            'label' => 'input_2, renderType=colorpicker',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'colorpicker'
@@ -127,32 +126,21 @@ return [
 
     'types' => [
         '0' => [
-            'showitem' => 'record_type, title, text_1',
+            'showitem' => 'record_type, input_1, text_1',
         ],
         'withChangedFields' => [
-            'showitem' => 'record_type, title, color, text_1',
+            'showitem' => 'record_type, input_1, input_2, text_1',
         ],
-        'withOverriddenColumns' => [
-            'showitem' => 'record_type, title, color, text_1',
+        'withColumnsOverrides' => [
+            'showitem' => 'record_type, input_1, input_2, text_1',
             'columnsOverrides' => [
-                'color' => [
+                'input_2' => [
                     'config' => [
                         'renderType' => '',
                         'readOnly' => true,
                         'size' => 10,
                     ],
                 ],
-                'text_1' => [
-                    'config' => [
-                        'renderType' => 't3editor',
-                        'format' => 'html',
-                    ],
-                ],
-            ],
-        ],
-        'test' => [
-            'showitem' => 'record_type, title, text_1',
-            'columnsOverrides' => [
                 'text_1' => [
                     'config' => [
                         'renderType' => 't3editor',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -663,8 +663,8 @@ CREATE TABLE tx_styleguide_staticdata (
 
 CREATE TABLE tx_styleguide_type (
     record_type text,
-    title text,
-    color text,
+    input_1 text,
+    input_2 text,
 	text_1 text
 );
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -660,8 +660,9 @@ CREATE TABLE tx_styleguide_staticdata (
 
 
 CREATE TABLE tx_styleguide_type (
-	type text,
-
+    record_type text,
+    title text,
+    color text,
 	text_1 text
 );
 


### PR DESCRIPTION
Improve record type example. rename column "type" to column "record_type" for more clarity. 
Introduce examples for using a different set of fields

'type' => 'type' isn't so easy to understand in the manual...

(cherry picked from commit adf77dd51f4797de655f474ef8044a43302535c2)