### PR TITLE
Default examples for radiobuttons

### DIFF
--- a/Configuration/TCA/tx_styleguide_valuesdefault.php
+++ b/Configuration/TCA/tx_styleguide_valuesdefault.php
@@ -176,8 +176,6 @@ return [
                 'default' => 2,
             ],
         ],
-
-
         'radio_2' => [
             'exclude' => 1,
             'label' => 'radio_2 default=y, three options, second pre-selected',
@@ -191,10 +189,9 @@ return [
                 'default' => 'y',
             ],
         ],
-
         'radio_3' => [
             'exclude' => 1,
-            'label' => 'radio_2 empty default',
+            'label' => 'radio_3 empty default',
             'config' => [
                 'type' => 'radio',
                 'items' => [

--- a/Configuration/TCA/tx_styleguide_valuesdefault.php
+++ b/Configuration/TCA/tx_styleguide_valuesdefault.php
@@ -177,6 +177,35 @@ return [
             ],
         ],
 
+
+        'radio_2' => [
+            'exclude' => 1,
+            'label' => 'radio_2 default=y, three options, second pre-selected',
+            'config' => [
+                'type' => 'radio',
+                'items' => [
+                    ['foo1', 'x'],
+                    ['foo2', 'y'],
+                    ['foo3', 'z'],
+                ],
+                'default' => 'y',
+            ],
+        ],
+
+        'radio_3' => [
+            'exclude' => 1,
+            'label' => 'radio_2 empty default',
+            'config' => [
+                'type' => 'radio',
+                'items' => [
+                    ['foo1', 'x'],
+                    ['foo2', 'y'],
+                    ['foo3', 'z'],
+                ],
+                'default' => '',
+            ],
+        ],
+
          // @todo add default value examples for type=none
 
         'select_1' => [
@@ -218,7 +247,7 @@ return [
                     input_1, input_2, input_3,
                     text_1,
                     checkbox_1, checkbox_2, checkbox_3,
-                    radio_1,
+                    radio_1, radio_2, radio_3,
                 --div--;select,
                     select_1,select_2,
             ',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -678,6 +678,8 @@ CREATE TABLE tx_styleguide_valuesdefault (
 	checkbox_3 int(11) DEFAULT '0' NOT NULL,
 
 	radio_1 int(11) DEFAULT '0' NOT NULL,
+    radio_2 text,
+    radio_3 text,
 
 	select_1 text,
 	select_2 text


### PR DESCRIPTION
empty default value selects none, radio buttons get selected by value, example where the value and ordal number are not the same to reduce confusion

(cherry picked from commit 46fbe22a2d3e9ae90613eba7f2c45a7d124192e5)