### PR TITLE
Remove windowOpenParameters option in inputLink

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -1469,7 +1469,6 @@ mod.web_layout.BackendLayouts {
                                                                 <options>
                                                                     <title>Link</title>
                                                                     <blindLinkOptions>mail,folder,spec</blindLinkOptions>
-                                                                    <windowOpenParameters>height=300,width=500,status=0,menubar=0,scrollbars=1</windowOpenParameters>
                                                                 </options>
                                                             </linkPopup>
                                                         </fieldControl>


### PR DESCRIPTION
InputLinks are opened with a modal instead of a new popup window.
This option has no effect here anymore.