### PR TITLE
[BUGFIX] Use correct naming for cell values

### DIFF
--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardTable.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardTable.php
@@ -44,7 +44,7 @@ class TypeTextWizardTable extends AbstractFieldGenerator implements FieldGenerat
     public function generate(array $data): string
     {
         return 'row1 col1|row1 col2'
-            . chr(10) . 'row2 col1|row3 col2'
-            . chr(10) . 'row2 col1|row3 col2';
+            . chr(10) . 'row2 col1|row2 col2'
+            . chr(10) . 'row3 col1|row3 col2';
     }
 }


### PR DESCRIPTION
The input values do not use correct values
according to their position in the table.
Changed the content generator to put
the right values in each row/column.