### PR TITLE
[TASK] Fix testing for MacOS and docker-compose 2

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -20,7 +20,9 @@ setUpDockerComposeDotEnv() {
     # Your local home directory for composer and npm caching
     echo "HOST_HOME=${HOME}" >> .env
     # Your local user
-    echo "ROOT_DIR"=${ROOT_DIR} >> .env
+    echo "ROOT_DIR=${ROOT_DIR}" >> .env
+    # Set home directory for composer, otherwise install from source will not work
+    echo "COMPOSER_HOME=${ROOT_DIR}/.Build/.composer" >> .env
     echo "HOST_USER=${USER}" >> .env
     echo "TEST_FILE=${TEST_FILE}" >> .env
     echo "PHP_XDEBUG_ON=${PHP_XDEBUG_ON}" >> .env
@@ -120,7 +122,7 @@ cd "$THIS_SCRIPT_DIR" || exit 1
 cd ../testing-docker || exit 1
 
 # Option defaults
-ROOT_DIR=`readlink -f ${PWD}/../../`
+ROOT_DIR=`realpath ${PWD}/../../`
 TEST_SUITE="unit"
 DBMS="mariadb"
 PHP_VERSION="7.4"

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   mssql2019latest:
     image: typo3/core-testing-mssql2019:latest
     environment:
-      ACCEPT_EULA: Y
+      ACCEPT_EULA: "Y"
       SA_PASSWORD: "Test1234!"
       MSSQL_PID: Developer
     # No tmpfs setup here since mssql fails on tmpfs o_direct.
@@ -32,7 +32,7 @@ services:
 
   web:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     stop_grace_period: 1s
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
@@ -45,7 +45,7 @@ services:
 
   acceptance_backend_mariadb10:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     links:
     - mariadb10
     - chrome
@@ -72,12 +72,12 @@ services:
         done;
         echo Database is up;
         php -v | grep '^PHP';
-        mkdir -p Web/typo3temp/var/tests/ \
-          && php -dxdebug.mode=off vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}
+        mkdir -p Web/typo3temp/var/tests/ &&  \
+        php -dxdebug.mode=off vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}
       "
   cgl:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
       - ${HOST_HOME}:${HOST_HOME}
@@ -100,7 +100,7 @@ services:
 
   composer_install:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
     - ${HOST_HOME}:${HOST_HOME}
@@ -118,7 +118,7 @@ services:
 
   composer_validate:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
     - ${HOST_HOME}:${HOST_HOME}
@@ -136,7 +136,7 @@ services:
 
   functional_mariadb10:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     links:
     - mariadb10
     volumes:
@@ -175,7 +175,7 @@ services:
 
   functional_mssql2019latest:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     links:
     - mssql2019latest
     volumes:
@@ -218,7 +218,7 @@ services:
 
   functional_postgres10:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     links:
     - postgres10
     volumes:
@@ -258,7 +258,7 @@ services:
 
   functional_sqlite:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
     - ${HOST_HOME}:${HOST_HOME}
@@ -287,7 +287,7 @@ services:
 
   lint:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
     - /etc/passwd:/etc/passwd:ro
@@ -304,7 +304,7 @@ services:
 
   phpstan:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
       - ${HOST_HOME}:${HOST_HOME}
@@ -322,7 +322,7 @@ services:
 
   unit:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: ${HOST_UID}
+    user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
       - ${HOST_HOME}:${HOST_HOME}


### PR DESCRIPTION
Changed syntax of docker-compose.yml to be compatible
with v2.0 and set composer home directory to make
sure source install will work.