### PR TITLE
[TASK] Add additional example for inputDateTime with range set

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -623,6 +623,20 @@ return [
                 'readOnly' => true,
             ],
         ],
+        'inputdatetime_11' => [
+            'exclude' => 1,
+            'label' => 'inputdatetime_11',
+            'description' => 'eval=datetime, default=0, range.lower=mktime (now)',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+                'default' => 0,
+                'range' => [
+                    'lower' => mktime(0, 0, 0, date('m'), date('d'), date('Y'))
+                ]
+            ],
+        ],
 
         'text_1' => [
             'l10n_mode' => 'prefixLangTitle description',
@@ -1753,6 +1767,7 @@ mod.web_layout.BackendLayouts {
                 --div--;inputDateTime,
                     inputdatetime_1, inputdatetime_2, inputdatetime_3, inputdatetime_4, inputdatetime_5,
                     inputdatetime_6, inputdatetime_7, inputdatetime_8, inputdatetime_9, inputdatetime_10,
+                    inputdatetime_11,
                 --div--;text,
                     text_1, text_2, text_3, text_4, text_5, text_6, text_7, text_8, text_9, text_10,
                     text_11, text_12, text_13, text_18, text_14, text_15, text_16, text_17, text_19,

--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -633,7 +633,7 @@ return [
                 'eval' => 'datetime',
                 'default' => 0,
                 'range' => [
-                    'lower' => mktime(0, 0, 0, date('m'), date('d'), date('Y'))
+                    'lower' => mktime(0, 0, 0, (int)date('m'), (int)date('d'), (int)date('Y'))
                 ]
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -626,14 +626,14 @@ return [
         'inputdatetime_11' => [
             'exclude' => 1,
             'label' => 'inputdatetime_11',
-            'description' => 'eval=datetime, default=0, range.lower=mktime (now)',
+            'description' => 'eval=datetime, default=0, range.lower=1627208536',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime',
                 'default' => 0,
                 'range' => [
-                    'lower' => mktime(0, 0, 0, (int)date('m'), (int)date('d'), (int)date('Y'))
+                    'lower' => 1627208536
                 ]
             ],
         ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -115,6 +115,7 @@ CREATE TABLE tx_styleguide_elements_basic (
     inputdatetime_8 text,
     inputdatetime_9 text,
     inputdatetime_10 text,
+    inputdatetime_11 text,
 
     text_1 text,
     text_2 text,


### PR DESCRIPTION
This allows us to test saving empty dates with a lower range set to
the current time. This is used for example in the endtime field for
pages and tt_content.