### PR TITLE
[TASK] runTests.sh: Use composer update instead of install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerInstall
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
 
       - name: Composer validate
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -47,7 +47,7 @@ Options:
         Specifies which test suite to run
             - acceptance: backend acceptance tests
             - cgl: cgl test and fix all php files
-            - composerInstall: "composer install", handy if host has no PHP, uses composer cache of users home
+            - composerUpdate: "composer update", handy if host has no PHP
             - composerValidate: "composer validate"
             - functional: functional tests
             - lint: PHP linting
@@ -226,9 +226,9 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;
-    composerInstall)
+    composerUpdate)
         setUpDockerComposeDotEnv
-        docker-compose run composer_install
+        docker-compose run composer_update
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -122,7 +122,7 @@ services:
         fi
       "
 
-  composer_install:
+  composer_update:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
@@ -137,7 +137,7 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
-        COMPOSER_HOME=${ROOT_DIR}/.Build/.composer composer install --no-progress --no-interaction;
+        COMPOSER_HOME=${ROOT_DIR}/.Build/.composer composer update --no-progress --no-interaction;
       "
 
   composer_validate:


### PR DESCRIPTION
When installing the test environment and having no composer.lock,
'composer update' should be used instead of 'composer install'.