### PR TITLE
[TASK] Avoid ExtensionTestEnvironment::prepare

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,11 +57,6 @@
       "TYPO3\\CMS\\Styleguide\\Tests\\": "Tests"
     }
   },
-  "scripts": {
-    "post-autoload-dump": [
-      "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
-    ]
-  },
   "extra": {
     "typo3/cms": {
       "app-dir": ".Build",


### PR DESCRIPTION
That test related helper class reference in
composer.json is obsolete in v11.

https://review.typo3.org/c/Packages/TYPO3.CMS/+/71029
https://forge.typo3.org/issues/94996