### PR TITLE
[TASK] Add additional autoSizeMax examples for type group and inline

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_group.php
+++ b/Configuration/TCA/tx_styleguide_elements_group.php
@@ -154,12 +154,13 @@ return [
         ],
         'group_db_11' => [
             'exclude' => 1,
-            'label' => 'group_db_11 hideSuggest=true allowed=tx_styleguide_staticdata, multiple',
+            'label' => 'group_db_11 hideSuggest=true allowed=tx_styleguide_staticdata, multiple, autoSizeMax=10',
             'config' => [
                 'type' => 'group',
                 'hideSuggest' => true,
                 'allowed' => 'tx_styleguide_staticdata',
                 'multiple' => true,
+                'autoSizeMax' => 10,
             ],
         ],
         'group_db_4' => [

--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -546,7 +546,7 @@ return [
 
         'select_multiplesidebyside_1' => [
             'exclude' => 1,
-            'label' => 'select_multiplesidebyside_1 autoSizeMax=5, size=3 description',
+            'label' => 'select_multiplesidebyside_1 autoSizeMax=10, size=3 description',
             'description' => 'field description',
             'config' => [
                 'type' => 'select',
@@ -561,7 +561,7 @@ return [
                     ['foo 6', 6],
                 ],
                 'size' => 3,
-                'autoSizeMax' => 5,
+                'autoSizeMax' => 10,
                 'multiple' => true,
             ],
         ],
@@ -663,7 +663,7 @@ return [
                 ],
                 'readOnly' => true,
                 'size' => 3,
-                'autoSizeMax' => 5,
+                'autoSizeMax' => 10,
                 'multiple' => true,
             ],
         ],
@@ -676,7 +676,7 @@ return [
                 'foreign_table' => 'tx_styleguide_staticdata',
                 'MM' => 'tx_styleguide_elements_select_multiplesidebyside_8_mm',
                 'size' => 3,
-                'autoSizeMax' => 5,
+                'autoSizeMax' => 10,
             ],
         ],
         'select_multiplesidebyside_9' => [
@@ -696,7 +696,7 @@ return [
         ],
         'select_multiplesidebyside_10' => [
             'exclude' => 1,
-            'label' => 'select_multiplesidebyside_1 autoSizeMax=5, size=3 description',
+            'label' => 'select_multiplesidebyside_1 autoSizeMax=10, size=3 description',
             'description' => 'field description',
             'config' => [
                 'type' => 'select',
@@ -713,7 +713,7 @@ return [
                     'group3' => 'Group 3 with items',
                 ],
                 'size' => 3,
-                'autoSizeMax' => 5,
+                'autoSizeMax' => 10,
                 'multiple' => true,
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombination.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombination.php
@@ -88,6 +88,7 @@ return [
                 'foreign_selector' => 'select_child',
                 'foreign_unique' => 'select_child',
                 'maxitems' => 9999,
+                'autoSizeMax' => 10,
                 'appearance' => [
                     'newRecordLinkAddTitle' => 1,
                     'useCombination' => true,


### PR DESCRIPTION
The option autoSizeMax is a common property between select, group and
inline fields. This patch adds examples for group and inline fields.

Inline fields have to fulfill special conditions for autoSizeMax
to be useful:
1. foreign_selector has to be defined.
2. The field, foreign_selector is pointing to, has to be of type select.

Only then a select field is rendered, which autoSizeMax can be applied
to.

Also increase the minimum value to at least 10 or else no effect will be
visible because of a css min-height of 156px in TYPO3 v11. This equals
~7 rows depending on the browser.