### PR TITLE
[TASK] Simplify items TCA of type=check

### DIFF
--- a/Configuration/TCA/tx_styleguide_ctrl_common.php
+++ b/Configuration/TCA/tx_styleguide_ctrl_common.php
@@ -68,7 +68,6 @@ return [
                'items' => [
                    [
                        0 => '',
-                       1 => '',
                        'invertStateDisplay' => true
                    ]
                ],

--- a/Configuration/TCA/tx_styleguide_displaycond.php
+++ b/Configuration/TCA/tx_styleguide_displaycond.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable'
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],
@@ -219,8 +217,8 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
-                    ['bar', ''],
+                    ['foo'],
+                    ['bar'],
                 ],
             ]
         ],

--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],
@@ -918,7 +916,7 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
+                    ['foo'],
                 ],
             ]
         ],
@@ -929,11 +927,10 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
-                    ['', ''],
+                    ['foo'],
+                    [''],
                     [
                         'foobar',
-                        '',
                         'iconIdentifierChecked' => 'content-beside-text-img-below-center',
                         'iconIdentifierUnchecked' => 'content-beside-text-img-below-center',
                     ],
@@ -947,15 +944,14 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
+                    ['foo'],
                     [
                         'foo and this here is very long text that maybe does not really fit into the form in one line.'
                         . ' Ok let us add even more text to see how this looks like if wrapped. Is this enough now? No?'
                         . ' Then let us add some even more useless text here!',
-                        ''
                     ],
-                    ['foobar', ''],
-                    ['foobar', ''],
+                    ['foobar'],
+                    ['foobar'],
                 ],
             ],
         ],
@@ -967,8 +963,8 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
-                    ['bar', ''],
+                    ['foo'],
+                    ['bar'],
                 ],
                 'itemsProcFunc' => 'TYPO3\\CMS\\Styleguide\\UserFunctions\\FormEngine\\TypeCheckbox8ItemsProcFunc->itemsProcFunc',
             ],
@@ -1005,8 +1001,8 @@ mod.web_layout.BackendLayouts {
                 'type' => 'check',
                 'readOnly' => 1,
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
+                    ['foo1'],
+                    ['foo2'],
                 ],
             ],
         ],
@@ -1017,9 +1013,9 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
                 ],
                 'cols' => '1',
             ],
@@ -1031,9 +1027,9 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
                 ],
                 'cols' => '2',
             ],
@@ -1045,10 +1041,10 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
-                    ['foo4', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
+                    ['foo4'],
                 ],
                 'cols' => '3',
             ],
@@ -1060,18 +1056,17 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
+                    ['foo1'],
+                    ['foo2'],
                     [
                         'foo3 and this here is very long text that maybe does not really fit into the'
                         . ' form in one line. Ok let us add even more text to see how',
-                        ''
                     ],
-                    ['foo4', ''],
-                    ['foo5', ''],
-                    ['foo6', ''],
-                    ['foo7', ''],
-                    ['foo8', ''],
+                    ['foo4'],
+                    ['foo5'],
+                    ['foo6'],
+                    ['foo7'],
+                    ['foo8'],
                 ],
                 'cols' => '4',
             ],
@@ -1083,13 +1078,13 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
-                    ['foo4', ''],
-                    ['foo5', ''],
-                    ['foo6', ''],
-                    ['foo7', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
+                    ['foo4'],
+                    ['foo5'],
+                    ['foo6'],
+                    ['foo7'],
                 ],
                 'cols' => '5',
             ],
@@ -1101,13 +1096,13 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
-                    ['foo4', ''],
-                    ['foo5', ''],
-                    ['foo6', ''],
-                    ['foo7', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
+                    ['foo4'],
+                    ['foo5'],
+                    ['foo6'],
+                    ['foo7'],
                 ],
                 'cols' => '6',
             ],
@@ -1119,13 +1114,13 @@ mod.web_layout.BackendLayouts {
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['Mo', ''],
-                    ['Tu', ''],
-                    ['We', ''],
-                    ['Th', ''],
-                    ['Fr', ''],
-                    ['Sa', ''],
-                    ['Su', ''],
+                    ['Mo'],
+                    ['Tu'],
+                    ['We'],
+                    ['Th'],
+                    ['Fr'],
+                    ['Sa'],
+                    ['Su'],
                 ],
                 'cols' => 'inline',
             ],
@@ -1140,7 +1135,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled'
                     ]
@@ -1157,7 +1151,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
                         'invertStateDisplay' => true
@@ -1175,7 +1168,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
                     ]
@@ -1192,19 +1184,16 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'On',
                         'labelUnchecked' => 'Off',
                     ],
                     [
                         0 => 'bar',
-                        1 => '',
                         'labelChecked' => 'On',
                         'labelUnchecked' => 'Off',
                     ],
                     [
                         0 => 'inv',
-                        1 => '',
                         'labelChecked' => 'On',
                         'labelUnchecked' => 'Off',
                         'invertStateDisplay' => true
@@ -1222,7 +1211,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
                         'invertStateDisplay' => true
@@ -1238,22 +1226,10 @@ mod.web_layout.BackendLayouts {
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
                 'items' => [
-                    [
-                        0 => 'foo',
-                        1 => '',
-                    ],
-                    [
-                        0 => 'bar',
-                        1 => '',
-                    ],
-                    [
-                        0 => 'baz',
-                        1 => '',
-                    ],
-                    [
-                        0 => 'husel',
-                        1 => '',
-                    ]
+                    ['foo'],
+                    ['bar'],
+                    ['baz'],
+                    ['husel']
                 ],
                 'cols' => '4',
             ]
@@ -1269,7 +1245,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled'
                     ]
@@ -1287,7 +1262,6 @@ mod.web_layout.BackendLayouts {
                 'items' => [
                     [
                         0 => 'foo',
-                        1 => '',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
                     ]

--- a/Configuration/TCA/tx_styleguide_elements_group.php
+++ b/Configuration/TCA/tx_styleguide_elements_group.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_imagemanipulation.php
+++ b/Configuration/TCA/tx_styleguide_elements_imagemanipulation.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_slugs.php
+++ b/Configuration/TCA/tx_styleguide_elements_slugs.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_special.php
+++ b/Configuration/TCA/tx_styleguide_elements_special.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_elements_t3editor.php
+++ b/Configuration/TCA/tx_styleguide_elements_t3editor.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_flex.php
+++ b/Configuration/TCA/tx_styleguide_flex.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_11.php
+++ b/Configuration/TCA/tx_styleguide_inline_11.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_11_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_11_child.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_1n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_1n1n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_1n1n_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n_child.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_1n1n_childchild.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n_childchild.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_expand.php
+++ b/Configuration/TCA/tx_styleguide_inline_expand.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable'
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_expandsingle.php
+++ b/Configuration/TCA/tx_styleguide_inline_expandsingle.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_expandsingle_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_expandsingle_child.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_fal.php
+++ b/Configuration/TCA/tx_styleguide_inline_fal.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults.php
+++ b/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults_child.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
+++ b/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
@@ -70,9 +70,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombination.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombination.php
@@ -27,9 +27,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombinationbox.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombinationbox.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_palette.php
+++ b/Configuration/TCA/tx_styleguide_palette.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_required.php
+++ b/Configuration/TCA/tx_styleguide_required.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable'
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_type.php
+++ b/Configuration/TCA/tx_styleguide_type.php
@@ -29,9 +29,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_typeforeign.php
+++ b/Configuration/TCA/tx_styleguide_typeforeign.php
@@ -29,9 +29,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],

--- a/Configuration/TCA/tx_styleguide_valuesdefault.php
+++ b/Configuration/TCA/tx_styleguide_valuesdefault.php
@@ -28,9 +28,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    '1' => [
-                        '0' => 'Disable',
-                    ],
+                    ['Disable'],
                 ],
             ],
         ],
@@ -135,7 +133,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo', ''],
+                    ['foo'],
                 ],
                 'default' => 1
             ]
@@ -146,10 +144,10 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['foo1', ''],
-                    ['foo2', ''],
-                    ['foo3', ''],
-                    ['foo4', ''],
+                    ['foo1'],
+                    ['foo2'],
+                    ['foo3'],
+                    ['foo4'],
                 ],
                 'default' => 5,
             ],
@@ -160,13 +158,13 @@ return [
             'config' => [
                 'type' => 'check',
                 'items' => [
-                    ['Mo', ''],
-                    ['Tu', ''],
-                    ['We', ''],
-                    ['Th', ''],
-                    ['Fr', ''],
-                    ['Sa', ''],
-                    ['Su', ''],
+                    ['Mo'],
+                    ['Tu'],
+                    ['We'],
+                    ['Th'],
+                    ['Fr'],
+                    ['Sa'],
+                    ['Su'],
                 ],
                 'cols' => 'inline',
                 'default' => 5,


### PR DESCRIPTION
This patch follows up this core patch:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/72056

The items array is reduced to the minimal viable setup.