### PR TITLE
[TASK] Set dependency for v11 as branching preparation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,21 +34,21 @@
     "bin-dir": ".Build/bin",
 	"preferred-install": {
 	  "typo3/cms-core": "source"
-	}
+	},
+    "sort-packages": true
   },
   "require-dev": {
-    "typo3/cms-core": "dev-master",
-    "typo3/cms-frontend": "dev-master",
-    "typo3/cms-install": "dev-master",
-    "typo3/cms-about": "dev-master",
-    "typo3/testing-framework": "^6.12.0",
     "codeception/codeception": "^4.1",
-    "codeception/module-webdriver": "^1.1",
     "codeception/module-asserts": "^1.2",
-    "typo3/coding-standards": "^0.3.0",
+    "codeception/module-cli": "^1.1",
+    "codeception/module-webdriver": "^1.1",
     "phpstan/phpstan": "^0.12.37",
+    "typo3/cms-core": "11.*.*@dev",
+    "typo3/cms-frontend": "11.*.*@dev",
+    "typo3/cms-install": "11.*.*@dev",
+    "typo3/coding-standards": "^0.3.0",
     "typo3/tailor": "^1.2",
-    "codeception/module-cli": "^1.1"
+    "typo3/testing-framework": "^6.14.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
Update dependencies to match v11 core development to get
tests green again. This is done as preparation to split
branch for v11. Composer package sorting is added as a
sideway change.

Note: 'typo3/cms-about' is removed as dependency as
      this has been merged to 'typo3/cms-backend'.

After branching dependencies should be set to match current
core master development.

This gets the tests green.

Used commands:

composer config sort-packages true
composer rem typo3/cms-about --dev --no-update
composer req typo3/cms-core:"11.*.*@dev" --dev --no-update
composer req typo3/cms-frontend:"11.*.*@dev" --dev --no-update
composer req typo3/cms-install:"11.*.*@dev" --dev --no-update
composer req typo3/testing-framework:"^6.14.0" --dev --no-update