### PR TITLE
[TASK] Run tests with PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.4', '8.0' ]
+        php: [ '7.4', '8.0', '8.1' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,6 +27,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
       - name: CGL
+        if: ${{ matrix.php != '8.1' }}
         run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
 
       - name: phpstan

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -62,10 +62,11 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite
 
-    -p <7.4|8.0>
+    -p <7.4|8.0|8.1>
         Specifies the PHP minor version to be used
             - 7.4 (default): use PHP 7.4
             - 8.0: use PHP 8.0
+            - 8.1: use PHP 8.1
 
     -e "<phpunit or codeception options>"
         Only with -s acceptance|functional|unit


### PR DESCRIPTION
Run casual tests, but disable php-cs-fixer with
8.1 for now since it is not yet compatible.