### PR TITLE
[BUGFIX] Use correct itemFormElValue

### DIFF
--- a/Classes/Form/Element/User1Element.php
+++ b/Classes/Form/Element/User1Element.php
@@ -42,7 +42,7 @@ class User1Element extends AbstractFormElement
             [
                 'type' => 'input',
                 'name' => $parameters['itemFormElName'],
-                'value' => $parameters['fieldChangeFunc'],
+                'value' => $parameters['itemFormElValue'],
             ],
             $this->getOnFieldChangeAttrs('change', $parameters['fieldChangeFunc'] ?? [])
         );


### PR DESCRIPTION
PR #255 unfortunately used wrong array index,
it should have been `itemFormElValue`.