### PR TITLE
[BUGFIX] Frontend user and groups & acceptance postgres & chrome revert

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,5 @@ jobs:
       - name: Acceptance Tests mysql and pdo_mysql
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s acceptance -d mysql -a pdo_mysql
 
-      # @todo Enable postgres testing after fixing issues with postgres, as tests currently fails with postgres
-      #- name: Acceptance Tests postgres
-      #  run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s acceptance -d postgres
+      - name: Acceptance Tests postgres
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s acceptance -d postgres

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   chrome:
-    image: selenium/standalone-chrome:4.0.0-20211102
+    image: selenium/standalone-chrome:3.141.59-20210713
     tmpfs:
       - /dev/shm:rw,nosuid,nodev,noexec,relatime
 

--- a/Configuration/TCA/Overrides/fe_groups.php
+++ b/Configuration/TCA/Overrides/fe_groups.php
@@ -1,0 +1,16 @@
+<?php
+
+defined('TYPO3') or die();
+
+call_user_func(function () {
+    // Add a field to pages table to identify styleguide demo pages.
+    // Field is handled by DataHandler and is not needed to be shown in BE, so it is of type "passthrough"
+    $additionalColumns = [
+        'tx_styleguide_containsdemo' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+    ];
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_groups', $additionalColumns);
+});

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,0 +1,16 @@
+<?php
+
+defined('TYPO3') or die();
+
+call_user_func(function () {
+    // Add a field to pages table to identify styleguide demo pages.
+    // Field is handled by DataHandler and is not needed to be shown in BE, so it is of type "passthrough"
+    $additionalColumns = [
+        'tx_styleguide_containsdemo' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+    ];
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', $additionalColumns);
+});

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -19,11 +19,11 @@ CREATE TABLE be_users (
 );
 
 CREATE TABLE fe_groups (
-    tx_styleguide_containsdemo tinyint(1) unsigned DEFAULT '0' NOT NULL
+    tx_styleguide_containsdemo varchar(255) DEFAULT '' NOT NULL
 );
 
 CREATE TABLE fe_users (
-    tx_styleguide_containsdemo tinyint(1) unsigned DEFAULT '0' NOT NULL
+    tx_styleguide_containsdemo varchar(255) DEFAULT '' NOT NULL
 );
 
 


### PR DESCRIPTION
First we change ext_tables.sql to fix an issue, not detecting styleguide
records correctly in 'fe_users' and 'fe_groups'.

Secondly we enable postgres acceptance testing, as this failed because
of the error which first commit has fixed.

Fourth, we revert the chrome driver raise as it seems that the raised
version is unstable for styleguide, when run as github action.

Last but not least, we add missing TCA for fe_users and fe_groups.