### PR TITLE
[BUGFIX] Ensure records are created with correct pid with sqlite

### DIFF
--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -83,9 +83,16 @@ class RecordFinder
                 $queryBuilder->expr()->eq(
                     'tx_styleguide_containsdemo',
                     $queryBuilder->createNamedParameter($tableName, \PDO::PARAM_STR)
+                ),
+                // only default language pages needed
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
                 )
             )
             ->orderBy('pid', 'DESC')
+            // add uid as deterministic last sorting, as not all dbms in all versions do that
+            ->addOrderBy('uid', 'ASC')
             ->execute()
             ->fetchAssociative();
         if (count($row) !== 1) {


### PR DESCRIPTION
Records has been created with the pid of a translated page,
not with the default language pid when executed with sqlite.
That came from the RecordFinder->findPidOfMainTableRecord()
method, which was not updated after page overlays had been
removed from the core. Many dbms and version automatically
adds a deterministic sorting criteria, if sorting would be
not deterministic - but not all.

This commit adds deterministic sorting to that method, filters
for default language only, which is what is wanted. Furthermore
generator test is adjusted to check not only for record count,
but if they are created on the correct page, at least for one
example data table.

Last but not least this commit replaces fetchColumn() with
fetchOne() in GeneratorTests as a preparation for doctrine/dbal
raise in the core, which has been overseen to replace with the
corresponding patch.

This patch acts as pre-patch to enable acceptance sqlite testing
in the core.