### PR TITLE
[BUGFIX] Ensure scheduled and pre-merge tests are happy again

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -11,10 +11,3 @@ parameters:
     - %currentWorkingDirectory%/Tests/Acceptance/Backend/GenerateCommandCest.php
 
   checkMissingIterableValueType: false
-
-  ignoreErrors:
-    # @todo: These should probably be fixed in core?!
-    -
-      message: "#^Parameter \\#1 \\.\\.\\.\\$where of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:orWhere\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-      count: 1
-      path: %currentWorkingDirectory%/Classes/TcaDataGenerator/RecordFinder.php

--- a/Classes/Form/Element/User1Element.php
+++ b/Classes/Form/Element/User1Element.php
@@ -18,6 +18,7 @@ namespace TYPO3\CMS\Styleguide\Form\Element;
 
 use TYPO3\CMS\Backend\Form\Behavior\OnFieldChangeTrait;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -28,7 +29,7 @@ class User1Element extends AbstractFormElement
     use OnFieldChangeTrait;
 
     /**
-     * @return array<string> As defined in initializeResultArray() of AbstractNode
+     * @return array<string, array<int, string|JavaScriptModuleInstruction>|string> As defined in initializeResultArray() of AbstractNode
      */
     public function render()
     {


### PR DESCRIPTION
This pull-requests contains two fixes to get the pre-merge and thus
the scheduled nightly for main branch green again, as it can be seen
here: https://github.com/sbuerk/styleguide/actions/runs/1697288968

- Remove unneded phpstan ignore configuration (fixed in core )
- Set correct method docblock to make phpstan happy again

These changes should not be backported for now. Adjustments for branch
11 and 10 will be provided in dedicated pull-requests, as they need
different and not fully solvable in the same way for now.