### PR TITLE
[BUGFIX] Adjust phpstan ignore pattern configuration

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -18,7 +18,9 @@ parameters:
       message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int.$#"
       count: 2
       path: %currentWorkingDirectory%/Tests/Functional/TcaDataGenerator/GeneratorTest.php
+    # @todo remove this after 11.5.6 release
     -
-      message: "#^Parameter \\#1 \\.\\.\\.\\$where of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:orWhere\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-      count: 1
+      message: "#^Parameter \\#1 \\.\\.\\.\\$where of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:orWhere\\(\\) expects array<int, string>|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
+      count: 5
       path: %currentWorkingDirectory%/Classes/TcaDataGenerator/RecordFinder.php
+


### PR DESCRIPTION
Adjust ignore pattern in phpstan configuration to ignore the updated
broken docblock of QueryBuilder::orWhere() in core with 11.5.5, and
add an todo to remove this after 11.5.6 release where this is fixed
correctly in core and makes the ignore pattern superflous.

See: https://github.com/sbuerk/styleguide/actions/runs/1697349484