### PR TITLE
[TASK] Add allowed plugins to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,12 @@
     "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true,
+            "composer/package-versions-deprecated": true
+        }
     },
     "require-dev": {
         "codeception/codeception": "^4.1",


### PR DESCRIPTION
composer 2.2.x checks if plugins are allowed, and if not asks for
confirmation to execute (and add) it.

This change adds the needed allowed plugins to composer.json, which
ensures tests can still run if composer version in core testing images
is raised.

Releases: main, 11, 10