### PR TITLE
[TASK] Avoid deprecated phpstan configuration 'excludes_analyse'

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -5,9 +5,11 @@ parameters:
     - %currentWorkingDirectory%/Classes
     - %currentWorkingDirectory%/Tests
 
-  excludes_analyse:
+  excludePaths:
     - %currentWorkingDirectory%/Tests/Acceptance/Support/BackendTester.php
     - %currentWorkingDirectory%/Tests/Acceptance/Backend/ModuleCest.php
     - %currentWorkingDirectory%/Tests/Acceptance/Backend/GenerateCommandCest.php
 
+  # @todo Disable vague typehints which comes with level 6. Remove this after typehints have been fixed.
+  #       See: https://phpstan.org/config-reference#vague-typehints
   checkMissingIterableValueType: false


### PR DESCRIPTION
PHPStan configuration option 'excludes_analyse' is deprecated and
should be replaced with the new option 'excludePaths' which would
prepare for PHPStan version raise. At least this suppress the
deprecation notice on phpstan execution.

Added a todo comment for option 'checkMissingIterableValueType'
why this is needed and when to recheck and remove along the way.

Readings:
https://gitanswer.com/rector-prepare-for-phpstan-1-0-1026148998 (BC breaks for end-users)
https://github.com/phpstan/phpstan-src/commit/d25c5e5a6c62a4537d4a108707ff26b5bea687d9

Releases: main, 11