### PR TITLE
[BUGFIX] Ensure acceptance tests works again on v10 branch

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -39,7 +39,20 @@ services:
     environment:
       TYPO3_PATH_ROOT: ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/acceptance
       TYPO3_PATH_APP: ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/acceptance
-    command: php -dxdebug.mode=off -S web:8000 -t ${ROOT_DIR}/.Build/Web
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          php -S web:8000 -t ${ROOT_DIR}/.Build/Web
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          php -S web:8000 -t ${ROOT_DIR}/.Build/Web
+        fi
+      "
 
   acceptance_backend_mariadb10:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
@@ -59,6 +72,8 @@ services:
     - /etc/passwd:/etc/passwd:ro
     - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -70,8 +85,17 @@ services:
         done;
         echo Database is up;
         php -v | grep '^PHP';
-        mkdir -p Web/typo3temp/var/tests/ \
-          && php -dxdebug.mode=off vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}
+        mkdir -p Web/typo3temp/var/tests/
+        COMMAND=\"vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}\"
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          $${COMMAND};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          $${COMMAND};
+        fi
       "
   cgl:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest

--- a/Tests/Acceptance/Fixtures/be_sessions.xml
+++ b/Tests/Acceptance/Fixtures/be_sessions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<be_sessions>
+        <!-- hash_hmac('md5', '886526ce72b86870739cc41991144ec1', sha1('iAmInvalid' . 'core-session-backend')) -->
+		<ses_id>a7475832dbc0aa7ed07bb1f800520d16</ses_id>
+		<ses_iplock>[DISABLED]</ses_iplock>
+		<ses_userid>1</ses_userid>
+		<ses_tstamp>1777777777</ses_tstamp>
+		<ses_data></ses_data>
+		<ses_backuserid>0</ses_backuserid>
+	</be_sessions>
+	<be_sessions>
+        <!-- hash_hmac('md5', 'ff83dfd81e20b34c27d3e97771a4525a', sha1('iAmInvalid' . 'core-session-backend')) -->
+		<ses_id>b99a7e54850ef064b7181d0de7d67900</ses_id>
+		<ses_iplock>[DISABLED]</ses_iplock>
+		<ses_userid>2</ses_userid>
+		<ses_tstamp>1777777777</ses_tstamp>
+		<ses_data></ses_data>
+		<ses_backuserid>0</ses_backuserid>
+	</be_sessions>
+</dataset>

--- a/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
@@ -44,7 +44,7 @@ class BackendStyleguideEnvironment extends BackendEnvironment
         ],
         'xmlDatabaseFixtures' => [
             'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
-            'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
+            'EXT:styleguide/Tests/Acceptance/Fixtures/be_sessions.xml',
             'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
         ],
     ];


### PR DESCRIPTION
This pull-requests fix the github ci testing for branch 10,
which was broken due an incompatible updated fixture file
in testing_framework. Additional it adds acceptance xdebug
debugging ability to this branch as a follow up.