### PR TITLE
[TASK] Align styleguide to changed min core requirements 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
+          # @todo Verify that tailor is PHP8.1 compatible and raise version to 8.1 here.
           php-version: 7.4
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,12 +47,6 @@ jobs:
       - name: Functional Tests with mysql and pdo_mysql
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mysql -a pdo_mysql -s functional
 
-      - name: Functional Tests with mssql and sqlsrv
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mssql -a sqlsrv -s functional
-
-      - name: Functional Tests with mssql and pdo_sqlsrv
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mssql -a pdo_sqlsrv -s functional
-
       - name: Functional Tests with postgres
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '8.1' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
       - name: CGL
-        if: ${{ matrix.php != '8.1' }}
         run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
 
       - name: phpstan

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -77,7 +77,7 @@ a recent docker-compose (tested >=1.21.2) is needed.
 
 Usage: $0 [options] [file]
 
-No arguments: Run all unit tests with PHP 7.4
+No arguments: Run all unit tests with PHP 8.1
 
 Options:
     -s <...>
@@ -113,11 +113,9 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite (not for -s acceptance)
 
-    -p <7.4|8.0|8.1>
+    -p <8.1>
         Specifies the PHP minor version to be used
-            - 7.4 (default): use PHP 7.4
-            - 8.0: use PHP 8.0
-            - 8.1: use PHP 8.1
+            - 8.1 (default): use PHP 8.1
 
     -e "<phpunit or codeception options>"
         Only with -s acceptance|functional|unit
@@ -153,7 +151,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 7.4
+    # Run unit tests using PHP 8.1
     ./Build/Scripts/runTests.sh
 EOF
 
@@ -180,7 +178,7 @@ else
 fi
 TEST_SUITE="unit"
 DBMS="mariadb"
-PHP_VERSION="7.4"
+PHP_VERSION="8.1"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 EXTRA_TEST_OPTIONS=""
@@ -207,6 +205,9 @@ while getopts ":s:a:d:p:e:xy:nhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(8.1)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi            
             ;;
         e)
             EXTRA_TEST_OPTIONS=${OPTARG}

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -295,7 +295,7 @@ case ${TEST_SUITE} in
     cgl)
         # Active dry-run for cgl needs not "-n" but specific options
         if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
-            CGLCHECK_DRY_RUN="--dry-run --diff --diff-format udiff"
+            CGLCHECK_DRY_RUN="--dry-run --diff"
         fi
         setUpDockerComposeDotEnv
         docker-compose run cgl

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -269,7 +269,7 @@ case ${TEST_SUITE} in
         case ${DBMS} in
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"
-                docker-compose run acceptance_backend_mysql55
+                docker-compose run acceptance_backend_mysql80
                 SUITE_EXIT_CODE=$?
                 ;;
             mariadb)
@@ -322,7 +322,7 @@ case ${TEST_SUITE} in
                 ;;
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"
-                docker-compose run functional_mysql55
+                docker-compose run functional_mysql80
                 SUITE_EXIT_CODE=$?
                 ;;
             postgres)

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -91,7 +91,7 @@ Options:
             - phpstan: phpstan analyze
             - unit (default): PHP unit tests
 
-    -a <mysqli|pdo_mysql|sqlsrv|pdo_sqlsrv>
+    -a <mysqli|pdo_mysql>
         Only with -s acceptance,functional
         Specifies to use another driver, following combinations are available:
             - mysql
@@ -100,16 +100,12 @@ Options:
             - mariadb
                 - mysqli (default)
                 - pdo_mysql
-            - mssql
-                - sqlsrv (default)
-                - pdo_sqlsrv
 
-    -d <mariadb|mysql|mssql|postgres|sqlite>
+    -d <mariadb|mysql|postgres|sqlite>
         Only with -s acceptance,functional
         Specifies on which DBMS tests are performed
             - mariadb (default): use mariadb
             - mysql: use mysql
-            - mssql: use mssql microsoft sql server (not for -s acceptance)
             - postgres: use postgres
             - sqlite: use sqlite (not for -s acceptance)
 
@@ -327,11 +323,6 @@ case ${TEST_SUITE} in
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"
                 docker-compose run functional_mysql55
-                SUITE_EXIT_CODE=$?
-                ;;
-            mssql)
-                echo "Using driver: ${DATABASE_DRIVER}"
-                docker-compose run functional_mssql2019latest
                 SUITE_EXIT_CODE=$?
                 ;;
             postgres)

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -20,15 +20,6 @@ services:
     tmpfs:
       - /var/lib/mysql/:rw,noexec,nosuid
 
-  mssql2019latest:
-    image: typo3/core-testing-mssql2019:latest
-    environment:
-      ACCEPT_EULA: "Y"
-      SA_PASSWORD: "Test1234!"
-      MSSQL_PID: Developer
-    # No tmpfs setup here since mssql fails on tmpfs o_direct.
-    # This makes mssql sloooow for functionals.
-
   postgres10:
     image: postgres:10-alpine
     environment:
@@ -350,50 +341,6 @@ services:
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
           bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
-        fi
-      "
-
-  functional_mssql2019latest:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
-    user: "${HOST_UID}"
-    links:
-    - mssql2019latest
-    volumes:
-    - ${ROOT_DIR}:${ROOT_DIR}
-    - ${HOST_HOME}:${HOST_HOME}
-    - /etc/passwd:/etc/passwd:ro
-    - /etc/group:/etc/group:ro
-    environment:
-      typo3DatabaseDriver: "${DATABASE_DRIVER}"
-      typo3DatabaseName: func
-      typo3DatabasePassword: "Test1234!"
-      typo3DatabaseUsername: SA
-      typo3DatabasePort: 1433
-      typo3DatabaseCharset: utf-8
-      typo3DatabaseHost: mssql2019latest
-    working_dir: ${ROOT_DIR}/.Build
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    command: >
-      /bin/sh -c "
-        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
-          set -x
-        fi
-        echo Waiting for database start...;
-        while ! nc -z mssql2019latest 1433; do
-          sleep 1;
-        done;
-        sleep 5;
-        echo Database is up;
-        php -v | grep '^PHP';
-        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
-          XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-mssql ${TEST_FILE};
-        else
-          XDEBUG_MODE=\"debug,develop\" \
-          XDEBUG_TRIGGER=\"foo\" \
-          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-mssql ${TEST_FILE};
         fi
       "
 

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     tmpfs:
     - /var/lib/mysql/:rw,noexec,nosuid
 
-  mysql55:
-    image: mysql:5.5
+  mysql80:
+    image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: funcp
     tmpfs:
@@ -99,11 +99,11 @@ services:
         fi
       "
 
-  acceptance_backend_mysql55:
+  acceptance_backend_mysql80:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
-      - mysql55
+      - mysql80
       - chrome
       - web
     environment:
@@ -111,7 +111,7 @@ services:
       typo3DatabaseName: func_test
       typo3DatabaseUsername: root
       typo3DatabasePassword: funcp
-      typo3DatabaseHost: mysql55
+      typo3DatabaseHost: mysql80
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
       - ${HOST_HOME}:${HOST_HOME}
@@ -126,7 +126,7 @@ services:
           set -x
         fi
         echo Waiting for database start...;
-        while ! nc -z mysql55 3306; do
+        while ! nc -z mysql80 3306; do
           sleep 1;
         done;
         echo Database is up;
@@ -303,11 +303,11 @@ services:
         fi
       "
 
-  functional_mysql55:
+  functional_mysql80:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
-      - mysql55
+      - mysql80
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
       - ${HOST_HOME}:${HOST_HOME}
@@ -318,7 +318,7 @@ services:
       typo3DatabaseName: func_test
       typo3DatabaseUsername: root
       typo3DatabasePassword: funcp
-      typo3DatabaseHost: mysql55
+      typo3DatabaseHost: mysql80
     working_dir: ${ROOT_DIR}/.Build
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -328,7 +328,7 @@ services:
           set -x
         fi
         echo Waiting for database start...;
-        while ! nc -z mysql55 3306; do
+        while ! nc -z mysql80 3306; do
           sleep 1;
         done;
         echo Database is up;

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -220,7 +220,7 @@ services:
             .Build/bin/php-cs-fixer fix \
               -v \
               ${CGLCHECK_DRY_RUN} \
-              --config=.Build/vendor/typo3/coding-standards/templates/extension_php_cs.dist \
+              --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
               --using-cache=no .
         else
           XDEBUG_MODE=\"debug,develop\" \
@@ -230,7 +230,7 @@ services:
           .Build/bin/php-cs-fixer fix \
             -v \
             ${CGLCHECK_DRY_RUN} \
-            --config=.Build/vendor/typo3/coding-standards/templates/extension_php_cs.dist \
+            --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
             --using-cache=no .
         fi
       "

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -71,7 +71,7 @@ class BackendController extends ActionController
         $this->moduleTemplate = $moduleTemplate;
         $moduleTemplate->setFlashMessageQueue($this->getFlashMessageQueue());
         $this->view->assign('actions', ['index', 'typography', 'tca', 'trees', 'tab', 'tables', 'avatar', 'buttons',
-            'infobox', 'flashMessages', 'icons', 'debug', 'modal', 'accordion', 'pagination']);
+            'infobox', 'flashMessages', 'icons', 'debug', 'modal', 'accordion', 'pagination', ]);
         $this->view->assign('currentAction', $this->request->getControllerActionName());
 
         // Shortcut button
@@ -80,7 +80,7 @@ class BackendController extends ActionController
         if (!empty($arguments['controller']) && !empty($arguments['action'])) {
             $shortcutArguments['tx_styleguide_help_styleguidestyleguide'] = [
                 'controller' => $arguments['controller'],
-                'action' => $arguments['action']
+                'action' => $arguments['action'],
             ];
         }
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
@@ -161,7 +161,7 @@ class BackendController extends ActionController
             $json = [
                 'title' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaCreateActionFailedTitle', 'styleguide'),
                 'body' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaCreateActionFailedBody', 'styleguide'),
-                'status' => AbstractMessage::ERROR
+                'status' => AbstractMessage::ERROR,
             ];
         } else {
             $generator = GeneralUtility::makeInstance(Generator::class);
@@ -171,7 +171,7 @@ class BackendController extends ActionController
             $json = [
                 'title' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaCreateActionOkTitle', 'styleguide'),
                 'body' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaCreateActionOkBody', 'styleguide'),
-                'status' => AbstractMessage::OK
+                'status' => AbstractMessage::OK,
             ];
         }
         // And redirect to display action
@@ -189,7 +189,7 @@ class BackendController extends ActionController
         $json = [
             'title' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaDeleteActionOkTitle', 'styleguide'),
             'body' => LocalizationUtility::translate($this->languageFilePrefix . 'tcaDeleteActionOkBody', 'styleguide'),
-            'status' => AbstractMessage::OK
+            'status' => AbstractMessage::OK,
         ];
 
         return new JsonResponse($json);
@@ -267,16 +267,16 @@ class BackendController extends ActionController
         $menuItems = [
             0 => [
                 'label' => 'First label',
-                'content' => 'First content'
+                'content' => 'First content',
             ],
             1 => [
                 'label' => 'Second label',
-                'content' => 'Second content'
+                'content' => 'Second content',
             ],
             2 => [
                 'label' => 'Third label',
-                'content' => 'Third content'
-            ]
+                'content' => 'Third content',
+            ],
         ];
         $tabs = $module->getDynamicTabMenu($menuItems, 'ident');
         $this->view->assign('tabs', $tabs);
@@ -357,7 +357,7 @@ class BackendController extends ActionController
             'paginator' => $paginator,
             'pagination' => new SimplePagination($paginator),
             'userGroups' => $userGroupArray,
-            'dateTimeFormat' => 'h:m d-m-Y'
+            'dateTimeFormat' => 'h:m d-m-Y',
         ]);
 
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Styleguide/Pagination');
@@ -372,7 +372,7 @@ class BackendController extends ActionController
             $json = [
               'title' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendCreateActionFailedTitle', 'styleguide'),
               'body' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendCreateActionFailedBody', 'styleguide'),
-              'status' => AbstractMessage::ERROR
+              'status' => AbstractMessage::ERROR,
             ];
         } else {
             $frontend = GeneralUtility::makeInstance(GeneratorFrontend::class);
@@ -381,7 +381,7 @@ class BackendController extends ActionController
             $json = [
                 'title' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendCreateActionOkTitle', 'styleguide'),
                 'body' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendCreateActionOkBody', 'styleguide'),
-                'status' => AbstractMessage::OK
+                'status' => AbstractMessage::OK,
             ];
         }
 
@@ -396,7 +396,7 @@ class BackendController extends ActionController
         $json = [
             'title' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendDeleteActionOkTitle', 'styleguide'),
             'body' => LocalizationUtility::translate($this->languageFilePrefix . 'frontendDeleteActionOkBody', 'styleguide'),
-            'status' => AbstractMessage::OK
+            'status' => AbstractMessage::OK,
         ];
 
         return new JsonResponse($json);

--- a/Classes/TcaDataGenerator/AbstractGenerator.php
+++ b/Classes/TcaDataGenerator/AbstractGenerator.php
@@ -132,8 +132,8 @@ abstract class AbstractGenerator
                     'fallbacks' => '',
                     'flag' => 'es',
                     'languageId' => $highestLanguageId + 4,
-                ]
-            ]
+                ],
+            ],
         ];
         $siteConfiguration->write($siteIdentifier, $configuration);
     }

--- a/Classes/TcaDataGenerator/GeneratorFrontend.php
+++ b/Classes/TcaDataGenerator/GeneratorFrontend.php
@@ -86,7 +86,7 @@ class GeneratorFrontend extends AbstractGenerator
                     'constants' => '# see EXT:styleguide/Configuration/TypoScript',
                     'config' => '# see EXT:styleguide/Configuration/TypoScript',
                     'pid' => $newIdOfEntryPage,
-                ]
+                ],
             ],
             'tt_content' => [
                 $newIdOfEntryContent => [
@@ -95,21 +95,21 @@ class GeneratorFrontend extends AbstractGenerator
                     'bodytext' => 'This is the generated frontend for the Styleguide Extension. This consists of all default content elements of the TYPO3 Core.',
                     'pid' => $newIdOfEntryPage,
                     'tx_styleguide_containsdemo' => 'tx_styleguide_frontend',
-                ]
+                ],
             ],
             'sys_category' => [
                 $newIdOfCategory => [
                     'title' => 'Styleguide Demo Category',
                     'pid' => $newIdOfEntryPage,
-                ]
+                ],
             ],
             'fe_groups' => [
                 $newIdOfFrontendGroup => [
                     'title' => 'Styleguide Frontend Demo',
                     'hidden' => 0,
                     'pid' => $newIdOfUserFolder,
-                    'tx_styleguide_containsdemo' => 'tx_styleguide_frontend'
-                ]
+                    'tx_styleguide_containsdemo' => 'tx_styleguide_frontend',
+                ],
             ],
             'fe_users' => [
                 $newIdOfFrontendUser => [
@@ -119,9 +119,9 @@ class GeneratorFrontend extends AbstractGenerator
                     // Password of demo frontend user: 'password'
                     'password' => '$argon2i$v=19$m=65536,t=16,p=1$VjFaWDFGMmh6RlNEWjY2Vw$Vp5lFrbe8/GNwIrlXnUm6m2d9JJPfkQudnD8sBQKG9A',
                     'pid' => $newIdOfUserFolder,
-                    'tx_styleguide_containsdemo' => 'tx_styleguide_frontend'
-                ]
-            ]
+                    'tx_styleguide_containsdemo' => 'tx_styleguide_frontend',
+                ],
+            ],
         ];
 
         $neighborPage = $newIdOfEntryPage;
@@ -228,20 +228,20 @@ class GeneratorFrontend extends AbstractGenerator
             'bullets' => [
                 [
                     'header' => 'A bullet list',
-                    'bodytext' => "Item 1\nItem 2\nItem 3\n"
+                    'bodytext' => "Item 1\nItem 2\nItem 3\n",
                 ],
                 [
                     'header' => 'Another bullet list',
-                    'bodytext' => "Item 4\nItem 5\nItem 6\n"
-                ]
+                    'bodytext' => "Item 4\nItem 5\nItem 6\n",
+                ],
             ],
             'div' => [
                 [
-                    'header' => $kauderWelsch->getLoremIpsum()
+                    'header' => $kauderWelsch->getLoremIpsum(),
                 ],
                 [
-                    'header' => $kauderWelsch->getLoremIpsum()
-                ]
+                    'header' => $kauderWelsch->getLoremIpsum(),
+                ],
             ],
             'header' => [
                 [
@@ -249,12 +249,12 @@ class GeneratorFrontend extends AbstractGenerator
                 ],
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
-                    'header_layout' => 2
+                    'header_layout' => 2,
                 ],
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
-                    'header_layout' => 3
-                ]
+                    'header_layout' => 3,
+                ],
             ],
             'text' => [
                 [
@@ -266,7 +266,7 @@ class GeneratorFrontend extends AbstractGenerator
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'header_layout' => 3,
                     'bodytext' => $kauderWelsch->getLoremIpsumHtml() . ' ' . $kauderWelsch->getLoremIpsumHtml(),
-                ]
+                ],
             ],
             'textpic' => [ // @todo add images
                 [
@@ -279,7 +279,7 @@ class GeneratorFrontend extends AbstractGenerator
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'header_layout' => 2,
                     'bodytext' => $kauderWelsch->getLoremIpsumHtml() . ' ' . $kauderWelsch->getLoremIpsumHtml(),
-                ]
+                ],
             ],
             'textmedia' => [
                 [
@@ -292,20 +292,20 @@ class GeneratorFrontend extends AbstractGenerator
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'header_layout' => 2,
                     'bodytext' => $kauderWelsch->getLoremIpsumHtml() . ' ' . $kauderWelsch->getLoremIpsumHtml(),
-                    'imageorient' => 25
-                ]
+                    'imageorient' => 25,
+                ],
             ],
             'image' => [
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'bodytext' => $kauderWelsch->getLoremIpsumHtml() . ' ' . $kauderWelsch->getLoremIpsumHtml(),
-                ]
+                ],
             ],
             'html' => [
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'bodytext' => $kauderWelsch->getLoremIpsumHtml() . ' ' . $kauderWelsch->getLoremIpsumHtml(),
-                ]
+                ],
             ],
             'table' => [
                 [
@@ -315,12 +315,12 @@ class GeneratorFrontend extends AbstractGenerator
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
                     'bodytext' => "row1 col1|row1 col2|row1 col3|row1 col4\nrow2 col1|row2 col2|row2 col3|row2 col4\nrow3 col1|row3 col2|row3 col3|row3 col4\nrow4 col1|row4 col2|row4 col3|row4 col4",
-                ]
+                ],
             ],
             'felogin_login' => [
                 [
                     'header' => $kauderWelsch->getLoremIpsum(),
-                ]
+                ],
             ],
             'form_formframework' => [
                 [
@@ -330,12 +330,12 @@ class GeneratorFrontend extends AbstractGenerator
                             'sDEF' => [
                                 'lDEF' => [
                                     'settings.persistenceIdentifier' => [
-                                        'vDEF' => 'EXT:styleguide/Resources/Private/Forms/allfields.form.yaml'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
+                                        'vDEF' => 'EXT:styleguide/Resources/Private/Forms/allfields.form.yaml',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'header' => 'Simple form',
@@ -344,96 +344,96 @@ class GeneratorFrontend extends AbstractGenerator
                             'sDEF' => [
                                 'lDEF' => [
                                     'settings.persistenceIdentifier' => [
-                                        'vDEF' => 'EXT:styleguide/Resources/Private/Forms/simpleform.form.yaml'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                        'vDEF' => 'EXT:styleguide/Resources/Private/Forms/simpleform.form.yaml',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'list' => [
                 [
                     'header' => 'Indexed Search',
-                    'list_type' => 'indexedsearch_pi2'
-                ]
+                    'list_type' => 'indexedsearch_pi2',
+                ],
             ],
             'shortcut' => [
                 [
                     'header' => 'Shortcut',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'uploads' => [
                 [
                     'header' => 'Uploads',
-                ]
+                ],
             ],
             'menu_categorized_pages' => [
                 [
                     'header' => 'Menu categorized pages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_categorized_content' => [
                 [
                     'header' => 'Menu categorized content',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_pages' => [
                 [
                     'header' => 'Menu pages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_subpages' => [
                 [
                     'header' => 'Menu subpages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_sitemap' => [
                 [
                     'header' => 'Menu sitemap',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_section' => [
                 [
                     'header' => 'Menu section',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_abstract' => [
                 [
                     'header' => 'Menu abstract',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_recently_updated' => [
                 [
                     'header' => 'Menu recently updated',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_related_pages' => [
                 [
                     'header' => 'Menu related pages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_section_pages' => [
                 [
                     'header' => 'Menu section pages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
             'menu_sitemap_pages' => [
                 [
                     'header' => 'Menu sitemap pages',
-                    'records' => '' // UIDs 856,857,849
-                ]
+                    'records' => '', // UIDs 856,857,849
+                ],
             ],
         ];
     }
@@ -544,12 +544,12 @@ class GeneratorFrontend extends AbstractGenerator
                         'sDEF' => [
                             'lDEF' => [
                                 'settings.pages' => [
-                                    'vDEF' => $storageFeLogin
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                    'vDEF' => $storageFeLogin,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ];
         }
 

--- a/Classes/TcaDataGenerator/TableHandler/General.php
+++ b/Classes/TcaDataGenerator/TableHandler/General.php
@@ -53,7 +53,7 @@ class General extends AbstractTableHandler implements TableHandlerInterface
         // First insert an empty row and get the uid of this row since
         // some fields need this uid for relations later.
         $fieldValues = [
-            'pid' => $recordFinder->findPidOfMainTableRecord($tableName)
+            'pid' => $recordFinder->findPidOfMainTableRecord($tableName),
         ];
         if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['tstamp'])) {
             $fieldValues[$GLOBALS['TCA'][$tableName]['ctrl']['tstamp']] = $context->getAspect('date')->get('timestamp');

--- a/Configuration/TCA/tx_styleguide_ctrl_common.php
+++ b/Configuration/TCA/tx_styleguide_ctrl_common.php
@@ -23,7 +23,7 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
-            'endtime' => 'endtime'
+            'endtime' => 'endtime',
         ],
     ],
     'palettes' => [
@@ -36,8 +36,8 @@ return [
            'exclude' => true,
            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
            'config' => [
-               'type' => 'language'
-           ]
+               'type' => 'language',
+           ],
        ],
        'l10n_parent' => [
            'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -46,18 +46,18 @@ return [
                'type' => 'select',
                'renderType' => 'selectSingle',
                'items' => [
-                   ['', 0]
+                   ['', 0],
                ],
                'foreign_table' => 'sys_category',
                'foreign_table_where' => 'AND sys_category.pid=###CURRENT_PID### AND sys_category.sys_language_uid IN (-1,0)',
-               'default' => 0
-           ]
+               'default' => 0,
+           ],
        ],
        'l10n_diffsource' => [
            'config' => [
                'type' => 'passthrough',
-               'default' => ''
-           ]
+               'default' => '',
+           ],
        ],
        'hidden' => [
            'exclude' => true,
@@ -68,10 +68,10 @@ return [
                'items' => [
                    [
                        0 => '',
-                       'invertStateDisplay' => true
-                   ]
+                       'invertStateDisplay' => true,
+                   ],
                ],
-           ]
+           ],
        ],
        'starttime' => [
            'exclude' => true,
@@ -83,8 +83,8 @@ return [
                'default' => 0,
                'behaviour' => [
                    'allowLanguageSynchronization' => true,
-               ]
-           ]
+               ],
+           ],
        ],
        'endtime' => [
            'exclude' => true,
@@ -99,15 +99,15 @@ return [
                ],
                'behaviour' => [
                    'allowLanguageSynchronization' => true,
-               ]
-           ]
+               ],
+           ],
        ],
        'title' => [
            'label' => 'LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:minimalTableTitleField',
            'config' => [
                'type' => 'input',
                'width' => 200,
-               'eval' => 'trim,required'
+               'eval' => 'trim,required',
            ],
        ],
        'description' => [

--- a/Configuration/TCA/tx_styleguide_ctrl_minimal.php
+++ b/Configuration/TCA/tx_styleguide_ctrl_minimal.php
@@ -10,7 +10,7 @@ return [
        'title' => [
            'label' => 'LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:minimalTableTitleField',
            'config' => [
-               'type' => 'input'
+               'type' => 'input',
            ],
        ],
    ],

--- a/Configuration/TCA/tx_styleguide_displaycond.php
+++ b/Configuration/TCA/tx_styleguide_displaycond.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -49,8 +49,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required',
                 'foreign_table_where' => 'AND {#tx_styleguide_required}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -62,18 +62,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required',
                 'foreign_table_where' => 'AND {#tx_styleguide_required}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         // Tab FIELD REQ start
@@ -220,7 +220,7 @@ return [
                     ['foo'],
                     ['bar'],
                 ],
-            ]
+            ],
         ],
         'input_19' => [
             'exclude' => 1,
@@ -245,9 +245,9 @@ return [
                     'FIELD:checkbox_1:=:0',
                     'OR' => [
                         'FIELD:select_2:=:1',
-                        'FIELD:select_2:>:3'
-                    ]
-                ]
+                        'FIELD:select_2:>:3',
+                    ],
+                ],
             ],
             'config' => [
                 'type' => 'input',

--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_basic',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_basic}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_basic}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_basic',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_basic}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_basic}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'input_1' => [
@@ -89,7 +89,7 @@ return [
                 'type' => 'input',
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
-                ]
+                ],
             ],
         ],
         'input_2' => [
@@ -469,8 +469,8 @@ return [
                     'linkPopup' => [
                         'options' => [
                             'allowedExtensions' => 'png',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
             ],
         ],
@@ -532,7 +532,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'dbType' => 'date',
                 'eval' => 'date',
-                'default' => '0000-00-00'
+                'default' => '0000-00-00',
             ],
         ],
         'inputdatetime_3' => [
@@ -554,7 +554,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'dbType' => 'datetime',
                 'eval' => 'datetime',
-                'default' => '0000-00-00 00:00:00'
+                'default' => '0000-00-00 00:00:00',
             ],
         ],
         'inputdatetime_5' => [
@@ -631,8 +631,8 @@ return [
                 'eval' => 'datetime',
                 'default' => 0,
                 'range' => [
-                    'lower' => 1627208536
-                ]
+                    'lower' => 1627208536,
+                ],
             ],
         ],
 
@@ -890,7 +890,7 @@ backend_layout {
             'description' => 'field description',
             'config' => [
                 'type' => 'check',
-            ]
+            ],
         ],
         'checkbox_2' => [
             'exclude' => 1,
@@ -901,7 +901,7 @@ backend_layout {
                 'items' => [
                     ['foo'],
                 ],
-            ]
+            ],
         ],
         'checkbox_3' => [
             'exclude' => 1,
@@ -1119,10 +1119,10 @@ backend_layout {
                     [
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled'
-                    ]
+                        'labelUnchecked' => 'Disabled',
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_18' => [
             'exclude' => 1,
@@ -1136,10 +1136,10 @@ backend_layout {
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
-                        'invertStateDisplay' => true
-                    ]
+                        'invertStateDisplay' => true,
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_19' => [
             'exclude' => 1,
@@ -1153,9 +1153,9 @@ backend_layout {
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_20' => [
             'exclude' => 1,
@@ -1179,10 +1179,10 @@ backend_layout {
                         0 => 'inv',
                         'labelChecked' => 'On',
                         'labelUnchecked' => 'Off',
-                        'invertStateDisplay' => true
-                    ]
+                        'invertStateDisplay' => true,
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_21' => [
             'exclude' => 1,
@@ -1196,10 +1196,10 @@ backend_layout {
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
-                        'invertStateDisplay' => true
-                    ]
+                        'invertStateDisplay' => true,
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_24' => [
             'exclude' => 1,
@@ -1212,10 +1212,10 @@ backend_layout {
                     ['foo'],
                     ['bar'],
                     ['baz'],
-                    ['husel']
+                    ['husel'],
                 ],
                 'cols' => '4',
-            ]
+            ],
         ],
         'checkbox_25' => [
             'exclude' => 1,
@@ -1229,10 +1229,10 @@ backend_layout {
                     [
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled'
-                    ]
+                        'labelUnchecked' => 'Disabled',
+                    ],
                 ],
-            ]
+            ],
         ],
         'checkbox_26' => [
             'exclude' => 1,
@@ -1247,9 +1247,9 @@ backend_layout {
                         0 => 'foo',
                         'labelChecked' => 'Enabled',
                         'labelUnchecked' => 'Disabled',
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ],
 
         'radio_1' => [
@@ -1276,7 +1276,7 @@ backend_layout {
                         'foo and this here is very long text that maybe does not really fit into the form in one line.'
                         . ' Ok let us add even more text to see how this looks like if wrapped. Is this enough now?'
                         . ' No? Then let us add some even more useless text here!',
-                        1
+                        1,
                     ],
                     ['bar', 2],
                     ['foobar', 3],

--- a/Configuration/TCA/tx_styleguide_elements_group.php
+++ b/Configuration/TCA/tx_styleguide_elements_group.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_group',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_group}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_group}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_group',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_group}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_group}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'group_db_1' => [
@@ -179,7 +179,7 @@ return [
                 'type' => 'group',
                 'allowed' => 'be_users',
                 'readOnly' => 1,
-            ]
+            ],
         ],
         'group_db_7' => [
             'exclude' => 1,
@@ -201,10 +201,10 @@ return [
                 'suggestOptions' => [
                     'default' => [
                         'additionalSearchFields' => 'nav_title, alias, url',
-                        'addWhere' => 'AND pages.doktype = 1'
-                    ]
-                ]
-            ]
+                        'addWhere' => 'AND pages.doktype = 1',
+                    ],
+                ],
+            ],
         ],
 
         'group_folder_1' => [

--- a/Configuration/TCA/tx_styleguide_elements_imagemanipulation.php
+++ b/Configuration/TCA/tx_styleguide_elements_imagemanipulation.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_group',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_group}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_group}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_group',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_group}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_group}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'group_db_1' => [
             'exclude' => 1,
@@ -119,7 +119,7 @@ return [
             'description' => 'standard configuration',
             'config' => [
                 'type' => 'imageManipulation',
-                'file_field' => 'group_db_1'
+                'file_field' => 'group_db_1',
             ],
         ],
         'crop_2' => [
@@ -129,7 +129,7 @@ return [
             'config' => [
                 'type' => 'imageManipulation',
                 'file_field' => 'group_db_2',
-                'allowedExtensions' => 'png'
+                'allowedExtensions' => 'png',
             ],
         ],
         'crop_4' => [
@@ -139,7 +139,7 @@ return [
             'config' => [
                 'type' => 'imageManipulation',
                 'file_field' => 'group_db_2',
-                'allowedExtensions' => 'jpg'
+                'allowedExtensions' => 'jpg',
             ],
         ],
         'crop_3' => [
@@ -155,23 +155,23 @@ return [
                         'allowedAspectRatios' => [
                             '16:9' => [
                                 'title' => '16 / 9',
-                                'value' => 16 / 9
+                                'value' => 16 / 9,
                             ],
                             '3:2' => [
                                 'title' => '3 / 2',
-                                'value' => 3 / 2
+                                'value' => 3 / 2,
                             ],
                             '4:3' => [
                                 'title' => '4 / 3',
-                                'value' => 4 / 3
+                                'value' => 4 / 3,
                             ],
                             '1:1' => [
                                 'title' => '1 / 1',
-                                'value' => 1.0
+                                'value' => 1.0,
                             ],
                             'NaN' => [
                                 'title' => 'free',
-                                'value' => 0.0
+                                'value' => 0.0,
                             ],
                         ],
                         'selectedRatio' => 'NaN',
@@ -182,7 +182,7 @@ return [
                             'height' => 1.0,
                         ],
                     ],
-                ]
+                ],
             ],
         ],
         'crop_5' => [
@@ -197,7 +197,7 @@ return [
                         'allowedAspectRatios' => [
                             '1:1' => [
                                 'title' => '1 / 1',
-                                'value' => 1.0
+                                'value' => 1.0,
                             ],
                         ],
                     ],
@@ -206,15 +206,15 @@ return [
                         'allowedAspectRatios' => [
                             '4:3' => [
                                 'title' => '4 / 3',
-                                'value' => 4 / 3
+                                'value' => 4 / 3,
                             ],
                             'NaN' => [
                                 'title' => 'free',
-                                'value' => 0.0
+                                'value' => 0.0,
                             ],
                         ],
                     ],
-                ]
+                ],
             ],
         ],
         'crop_6' => [
@@ -230,7 +230,7 @@ return [
                         'allowedAspectRatios' => [
                             '1:1' => [
                                 'title' => '1 / 1',
-                                'value' => 1.0
+                                'value' => 1.0,
                             ],
                         ],
                         'selectedRatio' => '1:1',
@@ -241,7 +241,7 @@ return [
                             'height' => 0.8,
                         ],
                     ],
-                ]
+                ],
             ],
         ],
         'crop_7' => [
@@ -257,7 +257,7 @@ return [
                         'allowedAspectRatios' => [
                             '1:1' => [
                                 'title' => '1 / 1',
-                                'value' => 1.0
+                                'value' => 1.0,
                             ],
                         ],
                         'selectedRatio' => '1:1',
@@ -268,7 +268,7 @@ return [
                             'height' => 3 / 4,
                         ],
                     ],
-                ]
+                ],
             ],
         ],
         'crop_8' => [
@@ -284,7 +284,7 @@ return [
                         'allowedAspectRatios' => [
                             '1:1' => [
                                 'title' => '1 / 1',
-                                'value' => 1.0
+                                'value' => 1.0,
                             ],
                         ],
                         'selectedRatio' => '1:1',
@@ -300,10 +300,10 @@ return [
                                 'y' => 0.05,
                                 'width' => 1 / 4,
                                 'height' => 1 / 4,
-                            ]
+                            ],
                         ],
                     ],
-                ]
+                ],
             ],
         ],
     ],

--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'rte_1' => [
@@ -119,7 +119,7 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'richtextConfiguration' => 'minimal'
+                'richtextConfiguration' => 'minimal',
             ],
         ],
         'rte_5' => [
@@ -128,7 +128,7 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'richtextConfiguration' => 'full'
+                'richtextConfiguration' => 'full',
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_elements_rte_flex_1_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte_flex_1_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte_flex_1_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte_flex_1_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte_flex_1_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,35 +51,35 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte_flex_1_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte_flex_1_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte_flex_1_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'rte_1' => [
             'label' => 'rte_1',

--- a/Configuration/TCA/tx_styleguide_elements_rte_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,36 +51,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'rte_1' => [
             'label' => 'rte_1',

--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_select',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_select}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_select}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_select',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_select}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_select}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'select_single_1' => [
@@ -92,7 +92,7 @@ return [
                         'foo and this here is very long text that maybe does not really fit into the form in one line.'
                             . ' Ok let us add even more text to see how this looks like if wrapped. Is this enough now? No?'
                             . ' Then let us add some even more useless text here!',
-                        1
+                        1,
                     ],
                     ['bar', 'bar'],
                 ],
@@ -169,7 +169,7 @@ return [
                 'fileFolderConfig' => [
                     'folder' => 'EXT:styleguide/Resources/Public/Icons',
                     'allowedExtensions' => 'svg',
-                    'depth' => 1
+                    'depth' => 1,
                 ],
                 'fieldWizard' => [
                     'selectIcons' => [
@@ -271,7 +271,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'tx_styleguide_staticdata',
-                'MM' => 'tx_styleguide_elements_select_single_15_mm'
+                'MM' => 'tx_styleguide_elements_select_single_15_mm',
             ],
         ],
         'select_single_16' => [
@@ -329,7 +329,7 @@ return [
                     ['Cherry tree', 4],
                 ],
                 'sortItems' => [
-                    'label' => 'asc'
+                    'label' => 'asc',
                 ],
                 'size' => 4,
             ],
@@ -348,7 +348,7 @@ return [
                     ['Cherry tree', 4],
                 ],
                 'sortItems' => [
-                    'value' => 'desc'
+                    'value' => 'desc',
                 ],
                 'size' => 4,
             ],
@@ -367,7 +367,7 @@ return [
                     ['Cherry tree', 4],
                 ],
                 'sortItems' => [
-                    'tx_styleguide' => 'TYPO3\CMS\Styleguide\UserFunctions\FormEngine\SelectItemSorter->sortReverseTitles'
+                    'tx_styleguide' => 'TYPO3\CMS\Styleguide\UserFunctions\FormEngine\SelectItemSorter->sortReverseTitles',
                 ],
                 'size' => 4,
             ],
@@ -489,7 +489,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectCheckBox',
                 'appearance' => [
-                    'expandAll' => true
+                    'expandAll' => true,
                 ],
                 'items' => [
                     ['div 1', '--div--'],
@@ -630,8 +630,8 @@ return [
                     'editPopup' => [
                         'disabled' => false,
                         'options' => [
-                            'windowOpenParameters' => 'height=300,width=500,status=0,menubar=0,scrollbars=1'
-                        ]
+                            'windowOpenParameters' => 'height=300,width=500,status=0,menubar=0,scrollbars=1',
+                        ],
                     ],
                     'addRecord' => [
                         'disabled' => false,
@@ -688,7 +688,7 @@ return [
                     ['foo 2', 2],
                     ['foo 3', 3],
                     ['bar', 4],
-                ]
+                ],
             ],
         ],
         'select_multiplesidebyside_10' => [
@@ -754,7 +754,7 @@ return [
                     'appearance' => [
                         'expandAll' => true,
                         'showHeader' => false,
-                        'nonSelectableLevels' => '0,1'
+                        'nonSelectableLevels' => '0,1',
                     ],
                 ],
             ],
@@ -848,7 +848,7 @@ return [
                 'items' => [
                     [
                         'Just an item',
-                        1
+                        1,
                     ],
                     ['bar', 'bar'],
                     ['and yet another one', -1],

--- a/Configuration/TCA/tx_styleguide_elements_select_single_12_foreign.php
+++ b/Configuration/TCA/tx_styleguide_elements_select_single_12_foreign.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_elements_select_single_12_foreign',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_select_single_12_foreign}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_select_single_12_foreign}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,24 +52,24 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_select_single_12_foreign',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_select_single_12_foreign}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_select_single_12_foreign}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_elements_slugs.php
+++ b/Configuration/TCA/tx_styleguide_elements_slugs.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_rte',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_rte}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_rte}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'input_1' => [
@@ -116,11 +116,11 @@ return [
                     ],
                 ],
                 'appearance' => [
-                    'prefix' => \TYPO3\CMS\Styleguide\UserFunctions\FormEngine\SlugPrefix::class . '->getPrefix'
+                    'prefix' => \TYPO3\CMS\Styleguide\UserFunctions\FormEngine\SlugPrefix::class . '->getPrefix',
                 ],
                 'fallbackCharacter' => '-',
                 'eval' => 'uniqueInSite',
-                'default' => ''
+                'default' => '',
             ],
         ],
         'slug_2' => [
@@ -132,11 +132,11 @@ return [
                 'generatorOptions' => [
                     'fields' => ['input_1'],
                     'fieldSeparator' => '/',
-                    'prefixParentPageSlug' => true
+                    'prefixParentPageSlug' => true,
                 ],
                 'fallbackCharacter' => '-',
                 'eval' => 'uniqueInSite',
-                'default' => ''
+                'default' => '',
             ],
         ],
         'slug_4' => [
@@ -146,11 +146,11 @@ return [
                 'type' => 'slug',
                 'generatorOptions' => [
                     'fields' => ['input_1', 'input_2'],
-                    'prefixParentPageSlug' => false
+                    'prefixParentPageSlug' => false,
                 ],
                 'fallbackCharacter' => '-',
                 'eval' => 'uniqueInSite',
-                'default' => ''
+                'default' => '',
             ],
         ],
         'slug_5' => [
@@ -160,11 +160,11 @@ return [
                 'type' => 'slug',
                 'generatorOptions' => [
                     'fields' => [['input_1', 'input_2']],
-                    'prefixParentPageSlug' => false
+                    'prefixParentPageSlug' => false,
                 ],
                 'fallbackCharacter' => '-',
                 'eval' => 'uniqueInSite',
-                'default' => ''
+                'default' => '',
             ],
         ],
 
@@ -188,7 +188,7 @@ return [
                     'fields' => ['input_3'],
                     'replacements' => [
                         '(f/m)' => '',
-                        '/' => '-'
+                        '/' => '-',
                     ],
                 ],
                 'fallbackCharacter' => '-',

--- a/Configuration/TCA/tx_styleguide_elements_special.php
+++ b/Configuration/TCA/tx_styleguide_elements_special.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_special',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_special}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_special}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_special',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_special}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_special}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'special_custom_1' => [
@@ -155,7 +155,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['dummy entry', '0']
+                    ['dummy entry', '0'],
                 ],
                 'special' => 'tables',
             ],

--- a/Configuration/TCA/tx_styleguide_elements_t3editor.php
+++ b/Configuration/TCA/tx_styleguide_elements_t3editor.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         't3editor_1' => [

--- a/Configuration/TCA/tx_styleguide_elements_t3editor_flex_1_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_elements_t3editor_flex_1_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor_flex_1_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor_flex_1_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor_flex_1_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,36 +51,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor_flex_1_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor_flex_1_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor_flex_1_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         't3editor_1' => [
             'label' => 't3editor_1 description',

--- a/Configuration/TCA/tx_styleguide_elements_t3editor_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_elements_t3editor_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,36 +51,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_elements_t3editor_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_elements_t3editor_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_t3editor_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         't3editor_1' => [
             'label' => 't3editor_1 description',

--- a/Configuration/TCA/tx_styleguide_flex.php
+++ b/Configuration/TCA/tx_styleguide_flex.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_flex',
                 'foreign_table_where' => 'AND {#tx_styleguide_flex}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_flex}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_flex',
                 'foreign_table_where' => 'AND {#tx_styleguide_flex}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_flex}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'flex_file_1' => [

--- a/Configuration/TCA/tx_styleguide_flex_flex_3_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_flex_flex_3_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_flex_flex_3_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_flex_flex_3_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_flex_flex_3_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,36 +51,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_flex_flex_3_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_flex_flex_3_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_flex_flex_3_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'label' => 'input_1 description',

--- a/Configuration/TCA/tx_styleguide_inline_11.php
+++ b/Configuration/TCA/tx_styleguide_inline_11.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_11',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_11}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_11}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_11',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_11}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_11}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_11_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_11_child.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_11_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_11_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_11_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_11_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_11_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_11_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
         'input_1' => [
             'l10n_mode' => 'prefixLangTitle',

--- a/Configuration/TCA/tx_styleguide_inline_1n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [
@@ -93,7 +93,7 @@ return [
                     'showSynchronizationLink' => true,
                     'showAllLocalizationLink' => true,
                     'showPossibleLocalizationRecords' => true,
-                ]
+                ],
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_inline_1n1n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_1n1n_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n_child.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,30 +65,30 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'inline_1' => [
             'exclude' => 1,

--- a/Configuration/TCA/tx_styleguide_inline_1n1n_childchild.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n1n_childchild.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n_childchild',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n_childchild}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n_childchild}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,30 +65,30 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n1n_childchild',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n1n_childchild}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n1n_childchild}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'l10n_mode' => 'prefixLangTitle',

--- a/Configuration/TCA/tx_styleguide_inline_1n_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n_child.php
@@ -25,20 +25,20 @@ return [
             'config' => [
                 'type' => 'passthrough',
                 'default' => '',
-            ]
+            ],
         ],
         'disable' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.disable',
             'config' => [
-                'type' => 'check'
-            ]
+                'type' => 'check',
+            ],
         ],
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -49,13 +49,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -67,24 +67,24 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1n_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1n_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1n_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'l10n_mode' => 'prefixLangTitle',

--- a/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nnol10n.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1nnol10n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1nnol10n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nnol10n}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_1nnol10n',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_1nnol10n}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nnol10n}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_1nnol10n_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nnol10n_child.php
@@ -20,19 +20,19 @@ return [
         'disable' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.disable',
             'config' => [
-                'type' => 'check'
-            ]
+                'type' => 'check',
+            ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'l10n_mode' => 'prefixLangTitle',

--- a/Configuration/TCA/tx_styleguide_inline_expand.php
+++ b/Configuration/TCA/tx_styleguide_inline_expand.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expand',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expand}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expand}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expand',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expand}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expand}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_expand_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_expand_inline_1_child.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,8 +38,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expand_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expand_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expand_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -51,36 +51,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expand_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expand_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expand_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
 
         'dummy_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_expandsingle.php
+++ b/Configuration/TCA/tx_styleguide_inline_expandsingle.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -48,13 +48,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expandsingle',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expandsingle}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expandsingle}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -66,19 +66,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expandsingle',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expandsingle}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expandsingle}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_expandsingle_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_expandsingle_child.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expandsingle_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expandsingle_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expandsingle_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_expandsingle_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_expandsingle_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_expandsingle_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'input_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_fal.php
+++ b/Configuration/TCA/tx_styleguide_inline_fal.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_fal',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_fal}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_fal}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_fal',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_fal}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_fal}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [
@@ -87,7 +87,7 @@ return [
                 'inline_1',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference',
                     ],
                     'overrideChildTca' => [
                         'columns' => [
@@ -99,7 +99,7 @@ return [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                                 'showitem' => '
                                 --palette--;;imageoverlayPalette,
-                                --palette--;;filePalette'
+                                --palette--;;filePalette',
                             ],
                         ],
                     ],
@@ -114,7 +114,7 @@ return [
                 'inline_2',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference',
                     ],
                     'overrideChildTca' => [
                         'columns' => [
@@ -126,7 +126,7 @@ return [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                                 'showitem' => '
                                 --palette--;;imageoverlayPalette,
-                                --palette--;;filePalette'
+                                --palette--;;filePalette',
                             ],
                         ],
                     ],
@@ -164,7 +164,7 @@ return [
                         'showPossibleLocalizationRecords' => true,
                         'showAllLocalizationLink' => true,
                         'showSynchronizationLink' => true,
-                    ]
+                    ],
                 ],
                 $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
             ),

--- a/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults.php
+++ b/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_foreignrecorddefaults',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_foreignrecorddefaults}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_foreignrecorddefaults}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_foreignrecorddefaults',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_foreignrecorddefaults}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_foreignrecorddefaults}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_foreignrecorddefaults_child.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -47,13 +47,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_foreignrecorddefaults_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_foreignrecorddefaults_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_foreignrecorddefaults_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -65,19 +65,19 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_foreignrecorddefaults_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_foreignrecorddefaults_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_foreignrecorddefaults_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',
-                'default' => ''
-            ]
+                'default' => '',
+            ],
         ],
 
         'input_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,8 +40,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -53,26 +53,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'title' => [
@@ -83,7 +83,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'inline_1' => [
             'exclude' => 1,
@@ -98,7 +98,7 @@ return [
                     'showAllLocalizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                 ],
-            ]
+            ],
         ],
 
     ],
@@ -108,8 +108,8 @@ return [
             'showitem' => '
                 --div--;General, title, inline_1,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mm_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_child.php
@@ -27,8 +27,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -41,8 +41,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -54,26 +54,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'title' => [
@@ -84,7 +84,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'parents' => [
             'exclude' => 1,
@@ -116,7 +116,7 @@ return [
                     'showAllLocalizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                 ],
-            ]
+            ],
         ],
 
     ],
@@ -126,8 +126,8 @@ return [
             'showitem' => '
                 --div--;General, title, parents, inline_2,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
@@ -27,8 +27,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -41,8 +41,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm_childchild',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm_childchild}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm_childchild}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -54,26 +54,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mm_childchild',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mm_childchild}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mm_childchild}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'title' => [
@@ -84,7 +84,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'parents' => [
             'exclude' => 1,
@@ -111,8 +111,8 @@ return [
             'showitem' => '
                 --div--;General, title, parents,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mn.php
+++ b/Configuration/TCA/tx_styleguide_inline_mn.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,8 +40,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -53,26 +53,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'input_1' => [
@@ -83,7 +83,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'inline_1' => [
             'exclude' => 1,
@@ -99,7 +99,7 @@ return [
                     'showAllLocalizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                 ],
-            ]
+            ],
         ],
 
     ],
@@ -109,8 +109,8 @@ return [
             'showitem' => '
                 --div--;General, input_1, inline_1,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mn_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mn_child.php
@@ -27,8 +27,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -41,8 +41,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -54,26 +54,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'input_1' => [
@@ -84,7 +84,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'parents' => [
             'exclude' => 1,
@@ -111,8 +111,8 @@ return [
             'showitem' => '
                 --div--;General, input_1, parents,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mn_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mn_mm.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,8 +40,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -53,26 +53,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mn_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mn_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'parentid' => [
@@ -84,7 +84,7 @@ return [
                 'foreign_table_where' => "AND {#tx_styleguide_inline_mn}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn}.{#sys_language_uid}='###REC_FIELD_sys_language_uid###'",
                 'maxitems' => 1,
                 'localizeReferences' => 1,
-            ]
+            ],
         ],
         'childid' => [
             'label' => 'childid',
@@ -95,17 +95,17 @@ return [
                 'foreign_table_where' => "AND {#tx_styleguide_inline_mn_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mn_child}.{#sys_language_uid}='###REC_FIELD_sys_language_uid###'",
                 'maxitems' => 1,
                 'localizeReferences' => 1,
-            ]
+            ],
         ],
         'parentsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'childsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'check_1' => [
             'label' => 'check_1',
@@ -119,8 +119,8 @@ return [
         '0' => [
             'showitem' => '
                 --div--;General, parentid, childid, check_1,
-                --div--;Visibility, sys_language_uid, l18n_parent, l18n_diffsource, hidden, hotelsort, branchsort'
-        ]
+                --div--;Visibility, sys_language_uid, l18n_parent, l18n_diffsource, hidden, hotelsort, branchsort',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mngroup.php
+++ b/Configuration/TCA/tx_styleguide_inline_mngroup.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,7 +40,7 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mngroup',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mngroup}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mngroup}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
+                'default' => 0,
             ],
         ],
         'l10n_source' => [

--- a/Configuration/TCA/tx_styleguide_inline_mngroup_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mngroup_child.php
@@ -27,8 +27,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -41,7 +41,7 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mngroup',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mngroup}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mngroup}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
+                'default' => 0,
             ],
         ],
         'l10n_source' => [

--- a/Configuration/TCA/tx_styleguide_inline_mngroup_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mngroup_mm.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,8 +40,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mngroup_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mngroup_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mngroup_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -53,26 +53,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mngroup_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mngroup_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mngroup_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'parentid' => [
@@ -90,7 +90,7 @@ return [
                         'disabled' => true,
                     ],
                 ],
-            ]
+            ],
         ],
         'childid' => [
             'label' => 'childid',
@@ -107,17 +107,17 @@ return [
                         'disabled' => true,
                     ],
                 ],
-            ]
+            ],
         ],
         'parentsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'childsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'check_1' => [
             'label' => 'check_1',
@@ -131,8 +131,8 @@ return [
         '0' => [
             'showitem' => '
                 --div--;General, parentid, childid, check_1,
-                --div--;Visibility, sys_language_uid, l18n_parent, l18n_diffsource, hidden, hotelsort, branchsort'
-        ]
+                --div--;Visibility, sys_language_uid, l18n_parent, l18n_diffsource, hidden, hotelsort, branchsort',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mnsymmetric.php
+++ b/Configuration/TCA/tx_styleguide_inline_mnsymmetric.php
@@ -27,8 +27,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -41,8 +41,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mnsymmetric}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mnsymmetric}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -54,26 +54,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mnsymmetric}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mnsymmetric}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'input_1' => [
@@ -84,7 +84,7 @@ return [
                 'type' => 'input',
                 'size' => '30',
                 'eval' => 'required',
-            ]
+            ],
         ],
         'branches' => [
             'exclude' => 1,
@@ -104,7 +104,7 @@ return [
                     'showAllLocalizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                 ],
-            ]
+            ],
         ],
 
     ],
@@ -114,8 +114,8 @@ return [
             'showitem' => '
                 --div--;General, input_1, branches,
                 --div--;Visibility, sys_language_uid, l18n_parent,l18n_diffsource, hidden
-            '
-        ]
+            ',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_mnsymmetric_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mnsymmetric_mm.php
@@ -26,8 +26,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -40,8 +40,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mnsymmetric_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mnsymmetric_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -53,26 +53,26 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_mnsymmetric_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_mnsymmetric_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'hotelid' => [
@@ -83,7 +83,7 @@ return [
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric',
                 'maxitems' => 1,
                 'localizeReferences' => 1,
-            ]
+            ],
         ],
         'branchid' => [
             'label' => 'branchid',
@@ -93,17 +93,17 @@ return [
                 'foreign_table' => 'tx_styleguide_inline_mnsymmetric',
                 'maxitems' => 1,
                 'localizeReferences' => 1,
-            ]
+            ],
         ],
         'hotelsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'branchsort' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
     ],
 
@@ -111,8 +111,8 @@ return [
         '0' => [
             'showitem' => '
                 --div--;General, title, hotelid, branchid,
-                --div--;Visibility, sys_language_uid, l18n_parent, l10n_diffsource, hidden, hotelsort, branchsort'
-        ]
+                --div--;Visibility, sys_language_uid, l18n_parent, l10n_diffsource, hidden, hotelsort, branchsort',
+        ],
     ],
 
 ];

--- a/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
+++ b/Configuration/TCA/tx_styleguide_inline_parentnosoftdelete.php
@@ -24,8 +24,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -38,7 +38,7 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_parentnosoftdelete',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_parentnosoftdelete}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_parentnosoftdelete}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
+                'default' => 0,
             ],
         ],
         'l10n_source' => [
@@ -51,13 +51,13 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_parentnosoftdelete',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_parentnosoftdelete}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_parentnosoftdelete}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
@@ -119,7 +119,7 @@ return [
         '1' => [
             'showitem' => '
                 sys_language_uid, l10n_parent, l10n_diffsource, hidden, text_1, inline_1
-            '
+            ',
         ],
     ],
 

--- a/Configuration/TCA/tx_styleguide_inline_usecombination.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombination.php
@@ -35,8 +35,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -49,8 +49,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -62,18 +62,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_usecombination_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombination_child.php
@@ -25,15 +25,15 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'trim'
+                'eval' => 'trim',
             ],
         ],
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -46,8 +46,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -59,18 +59,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
     ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombination_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombination_mm.php
@@ -46,8 +46,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -60,8 +60,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -73,18 +73,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombination_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombination_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombination_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
     ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombinationbox.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombinationbox.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -50,8 +50,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -63,18 +63,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_usecombinationbox_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombinationbox_child.php
@@ -25,15 +25,15 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'trim'
+                'eval' => 'trim',
             ],
         ],
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -46,8 +46,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -59,18 +59,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
     ],

--- a/Configuration/TCA/tx_styleguide_inline_usecombinationbox_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_usecombinationbox_mm.php
@@ -46,8 +46,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -60,8 +60,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox_mm}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -73,18 +73,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_inline_usecombinationbox_mm',
                 'foreign_table_where' => 'AND {#tx_styleguide_inline_usecombinationbox_mm}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_usecombinationbox_mm}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
     ],

--- a/Configuration/TCA/tx_styleguide_palette.php
+++ b/Configuration/TCA/tx_styleguide_palette.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -50,8 +50,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_palette',
                 'foreign_table_where' => 'AND {#tx_styleguide_palette}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_palette}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -63,18 +63,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_palette',
                 'foreign_table_where' => 'AND {#tx_styleguide_palette}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_palette}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'palette_1_1' => [

--- a/Configuration/TCA/tx_styleguide_required.php
+++ b/Configuration/TCA/tx_styleguide_required.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -50,8 +50,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required',
                 'foreign_table_where' => 'AND {#tx_styleguide_required}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -63,18 +63,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required',
                 'foreign_table_where' => 'AND {#tx_styleguide_required}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'notrequired_1' => [

--- a/Configuration/TCA/tx_styleguide_required_flex_2_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_required_flex_2_inline_1_child.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required_flex_2_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_flex_2_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_flex_2_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,36 +52,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required_flex_2_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_flex_2_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_flex_2_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
-            ]
+                'default' => '0',
+            ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'label' => 'input_1 eval=required',

--- a/Configuration/TCA/tx_styleguide_required_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_required_inline_1_child.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_1_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,36 +52,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_1_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_1_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_1_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'label' => 'input_1',

--- a/Configuration/TCA/tx_styleguide_required_inline_2_child.php
+++ b/Configuration/TCA/tx_styleguide_required_inline_2_child.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_2_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_2_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_2_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,36 +52,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_2_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_2_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_2_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'label' => 'input_1',

--- a/Configuration/TCA/tx_styleguide_required_inline_3_child.php
+++ b/Configuration/TCA/tx_styleguide_required_inline_3_child.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_3_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_3_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_3_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,36 +52,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required_inline_3_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_inline_3_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_inline_3_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'input_1' => [
             'label' => 'input_1',

--- a/Configuration/TCA/tx_styleguide_required_rte_2_child.php
+++ b/Configuration/TCA/tx_styleguide_required_rte_2_child.php
@@ -25,8 +25,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -39,8 +39,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_required_rte_2_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_rte_2_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_rte_2_child}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -52,36 +52,36 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_required_rte_2_child',
                 'foreign_table_where' => 'AND {#tx_styleguide_required_rte_2_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_required_rte_2_child}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
         'hidden' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'default' => '0'
+                'default' => '0',
             ],
         ],
 
         'parentid' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'parenttable' => [
             'config' => [
                 'type' => 'passthrough',
-            ]
+            ],
         ],
         'rte_1' => [
             'label' => 'rte_1',

--- a/Configuration/TCA/tx_styleguide_type.php
+++ b/Configuration/TCA/tx_styleguide_type.php
@@ -37,8 +37,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -51,8 +51,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_type',
                 'foreign_table_where' => 'AND {#tx_styleguide_type}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_type}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -64,18 +64,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_type',
                 'foreign_table_where' => 'AND {#tx_styleguide_type}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_type}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'record_type' => [
@@ -94,14 +94,14 @@ return [
             'label' => 'input_1',
             'config' => [
                 'type' => 'input',
-            ]
+            ],
         ],
         'input_2' => [
             'label' => 'input_2, renderType=colorpicker',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'colorpicker'
-            ]
+                'renderType' => 'colorpicker',
+            ],
         ],
 
         'text_1' => [

--- a/Configuration/TCA/tx_styleguide_typeforeign.php
+++ b/Configuration/TCA/tx_styleguide_typeforeign.php
@@ -37,8 +37,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -51,8 +51,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_type',
                 'foreign_table_where' => 'AND {#tx_styleguide_type}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_type}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -64,18 +64,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_type',
                 'foreign_table_where' => 'AND {#tx_styleguide_type}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_type}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'foreign_table' => [
@@ -94,14 +94,14 @@ return [
             'label' => 'input_1',
             'config' => [
                 'type' => 'input',
-            ]
+            ],
         ],
         'input_2' => [
             'label' => 'input_2 renderType=colorpicker',
             'config' => [
                 'type' => 'input',
-                'renderType' => 'colorpicker'
-            ]
+                'renderType' => 'colorpicker',
+            ],
         ],
 
         'text_1' => [

--- a/Configuration/TCA/tx_styleguide_valuesdefault.php
+++ b/Configuration/TCA/tx_styleguide_valuesdefault.php
@@ -36,8 +36,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'language'
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
@@ -50,8 +50,8 @@ return [
                 ],
                 'foreign_table' => 'tx_styleguide_valuesdefault',
                 'foreign_table_where' => 'AND {#tx_styleguide_valuesdefault}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_valuesdefault}.{#sys_language_uid} IN (-1,0)',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_source' => [
             'exclude' => true,
@@ -63,18 +63,18 @@ return [
                 'items' => [
                     [
                         '',
-                        0
-                    ]
+                        0,
+                    ],
                 ],
                 'foreign_table' => 'tx_styleguide_valuesdefault',
                 'foreign_table_where' => 'AND {#tx_styleguide_valuesdefault}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_valuesdefault}.{#uid}!=###THIS_UID###',
-                'default' => 0
-            ]
+                'default' => 0,
+            ],
         ],
         'l10n_diffsource' => [
             'config' => [
-                'type' => 'passthrough'
-            ]
+                'type' => 'passthrough',
+            ],
         ],
 
         'input_1' => [
@@ -125,7 +125,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'default' => 1,
-            ]
+            ],
         ],
         'checkbox_2' => [
             'exclude' => 1,
@@ -135,8 +135,8 @@ return [
                 'items' => [
                     ['foo'],
                 ],
-                'default' => 1
-            ]
+                'default' => 1,
+            ],
         ],
         'checkbox_3' => [
             'exclude' => 1,
@@ -239,7 +239,7 @@ return [
                     ['foo 3', 3],
                     ['foo 4', 4],
                 ],
-                'default' => '1,3'
+                'default' => '1,3',
             ],
         ],
 

--- a/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
@@ -39,7 +39,7 @@ class BackendStyleguideEnvironment extends BackendEnvironment
             'recordlist',
         ],
         'testExtensionsToLoad' => [
-            'typo3conf/ext/styleguide'
+            'typo3conf/ext/styleguide',
         ],
         'xmlDatabaseFixtures' => [
             'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "typo3/cms-core": "~12.0@dev",
         "typo3/cms-frontend": "~12.0@dev",
         "typo3/cms-install": "~12.0@dev",
-        "typo3/coding-standards": "^0.3.0",
+        "typo3/coding-standards": "^0.5.0",
         "typo3/tailor": "^1.2",
         "typo3/testing-framework": "dev-main"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,10 +9,10 @@ $EM_CONF[$_EXTKEY] = [
     'state' => 'stable',
     'createDirs' => '',
     'clearCacheOnLoad' => 0,
-    'version' => '11.5.2',
+    'version' => '12.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-11.99.99',
+            'typo3' => '12.0.0-12.99.99',
         ],
         'conflicts' => [
         ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -9,7 +9,7 @@ defined('TYPO3') or die();
     'styleguide',
     '',
     [
-        \TYPO3\CMS\Styleguide\Controller\BackendController::class => 'index, typography, trees, tables, buttons, infobox, avatar, flashMessages, tca, tcaCreate, tcaDelete, debug, icons, tab, modal, accordion, pagination, frontendCreate, frontendDelete'
+        \TYPO3\CMS\Styleguide\Controller\BackendController::class => 'index, typography, trees, tables, buttons, infobox, avatar, flashMessages, tca, tcaCreate, tcaDelete, debug, icons, tab, modal, accordion, pagination, frontendCreate, frontendDelete',
     ],
     [
         'access' => 'user,group',
@@ -49,7 +49,7 @@ $iconRegistry->registerIcon(
     \TYPO3\CMS\Core\Imaging\IconProvider\FontawesomeIconProvider::class,
     [
         'name' => 'spinner',
-        'spinning' => true
+        'spinning' => true,
     ]
 );
 
@@ -64,9 +64,9 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_styleguide_custom'] =
                 'Description 1',
             ],
         'key2' => [
-            'Option 2'
+            'Option 2',
         ],
-    ]
+    ],
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_ctrl_common');


### PR DESCRIPTION
This pull-request multiple commits, to split up tasks in some logical
steps, even if tests getting green is reached nearly to the end.
I decided to avoid one big patch just to be green in one step.

1. ensure cgl is runnable with **PHP8.1**
2. applied updated cgl (necessary because of changed ruleset)
3. remove **PHP7.4** and **PHP8.0** from github testing and `runTests.sh`
4. removed **MSSQL support** (docker + runtests) and github testing
5. Update versions in `ext_emconf.php`.
6. Raise MySQL Server version to 8.0

This makes scheduled, pre-merge and push tests happy again.

Raise patch in core with updated hash for styleguide may be done
after merging this pull-request.

Backporting cgl update and php8.1 run support will be provided
by a seperate pull-request with two commits, if wanted.
Otherwise backport the first commit and afterwards run the command
from the second commit and create a new second commit for branch 11.

Recommend to merge commits as is (rebase merge) and not squashing them.