### PR TITLE
[TASK] Remove obsolete fullScreenRichtext fieldControl

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_rte.php
+++ b/Configuration/TCA/tx_styleguide_elements_rte.php
@@ -88,11 +88,6 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'fieldControl' => [
-                    'fullScreenRichtext' => [
-                        'disabled' => false,
-                    ],
-                ],
             ],
         ],
         'rte_2' => [


### PR DESCRIPTION
Since the introduction of ckeditor, this fieldControl
is not available anymore. The fullscreen option is
controlled in the editor yaml file.

Releases: main, 11