### PR TITLE
[TASK] Remove tableWizard example

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -805,8 +805,6 @@ return [
             'config' => [
                 'type' => 'text',
                 'renderType' => 'textTable',
-                'cols' => '40',
-                'rows' => '5',
             ],
         ],
         'text_18' => [
@@ -863,24 +861,6 @@ backend_layout {
     }
   }
 }',
-            ],
-        ],
-
-        'text_21' => [
-            'label' => 'text_21',
-            'description' => 'renderType=textTable tableWizard numNewRows=3',
-            'config' => [
-                'type' => 'text',
-                'renderType' => 'textTable',
-                'cols' => 40,
-                'rows' => 5,
-                'fieldControl' => [
-                    'tableWizard' => [
-                        'options' => [
-                            'numNewRows' => 3,
-                        ],
-                    ],
-                ],
             ],
         ],
 
@@ -1728,7 +1708,7 @@ backend_layout {
                 --div--;text,
                     text_1, text_2, text_3, text_4, text_5, text_6, text_7, text_9, text_10,
                     text_11, text_12, text_13, text_18, text_14, text_15, text_16, text_17, text_19,
-                    text_21, text_20,
+                    text_20,
                 --div--;check,
                     checkbox_1, checkbox_9, checkbox_2, checkbox_17, checkbox_25, checkbox_18, checkbox_24, checkbox_19, checkbox_26,
                     checkbox_20, checkbox_21, checkbox_22, checkbox_23, checkbox_3, checkbox_4, checkbox_6, checkbox_7, checkbox_8,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -140,7 +140,6 @@ CREATE TABLE tx_styleguide_elements_basic (
     text_18 text,
     text_19 text,
     text_20 text,
-    text_21 text,
 
     checkbox_1 int(11) DEFAULT '0' NOT NULL,
     checkbox_2 int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
The tableWizard as a fieldControl for the textTable element in gone in
TYPO3 v11:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/70823

Instead, it is always displayed inline. The real textarea field is now
hidden from the user.

Because of that, setting "rows" doesn't make any sense anymore, besides
when using together with "readOnly". Thus, it is removed from the
example.

Along with that "cols", "numNewRows" and "xmlOutput" are no longer
configurable.

The removed field text_21 is not used in TYPO3 acceptance tests, so it
needs no adjustments from that side.

Releases: main, 11.5