### PR TITLE
[TASK] Replace deprecated QueryBuilder->execute()

### DIFF
--- a/Classes/TcaDataGenerator/AbstractGenerator.php
+++ b/Classes/TcaDataGenerator/AbstractGenerator.php
@@ -153,7 +153,7 @@ abstract class AbstractGenerator
             ->from('pages')
             ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)))
             ->orderBy('sorting', 'DESC')
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
         $uid = 0;
         if (MathUtility::canBeInterpretedAsInteger($lastPage) && $lastPage > 0) {

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTableForType.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTableForType.php
@@ -53,7 +53,7 @@ class TypeSelectRenderTypeSingleForeignTableForType extends AbstractFieldGenerat
         return (string)$queryBuilder
             ->select('uid')
             ->from('tx_styleguide_type')
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
     }
 }

--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -55,7 +55,7 @@ class RecordFinder
                     $queryBuilder->createNamedParameter('tx_styleguide', \PDO::PARAM_STR)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
         $uids = [];
         if (is_array($rows)) {
@@ -95,7 +95,7 @@ class RecordFinder
             ->orderBy('pid', 'DESC')
             // add uid as deterministic last sorting, as not all dbms in all versions do that
             ->addOrderBy('uid', 'ASC')
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative();
         if (count($row) !== 1) {
             throw new Exception(
@@ -164,7 +164,7 @@ class RecordFinder
                     $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
         $result = [];
         if (is_array($rows)) {
@@ -192,7 +192,7 @@ class RecordFinder
                     $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
         $result = [];
         if (is_array($rows)) {
@@ -221,7 +221,7 @@ class RecordFinder
                     $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
         $result = [];
         if (is_array($rows)) {

--- a/Tests/Functional/TcaDataGenerator/GeneratorTest.php
+++ b/Tests/Functional/TcaDataGenerator/GeneratorTest.php
@@ -48,7 +48,7 @@ class GeneratorTest extends FunctionalTestCase
         $queryBuilder->getRestrictions()->removeAll();
         $count = (int)$queryBuilder->count('uid')
             ->from('tx_styleguide_elements_basic')
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
         self::assertEquals(0, $count);
 
@@ -66,7 +66,7 @@ class GeneratorTest extends FunctionalTestCase
                     $queryBuilder->createNamedParameter($this->getPageUidFor('tx_styleguide_elements_basic'), \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
         self::assertGreaterThan(0, $count);
     }
@@ -94,7 +94,7 @@ class GeneratorTest extends FunctionalTestCase
             ->orderBy('pid', 'DESC')
             // add uid as deterministic last sorting, as not all dbms in all versions do that
             ->addOrderBy('uid', 'ASC')
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative();
 
         if ($row['uid'] ?? false) {


### PR DESCRIPTION
TYPO3 v12 has deprecated the `QueryBuilder->execute()`
method to align with corresponding deprecation of the used
doctrine/dbal package with:

ISSUE: https://forge.typo3.org/issues/96972
PATCH: https://review.typo3.org/c/Packages/TYPO3.CMS/+/73610

This patch replaces corresponding 'execute()' calls with the
proper replacement method.

Releases: main