### PR TITLE
[TASK] Add type=folder examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,11 +36,6 @@ indent_size = 2
 [*.xlf]
 indent_style = tab
 
-# SQL-Files
-[*.sql]
-indent_style = tab
-indent_size = 2
-
 # .htaccess
 [{_.htaccess,.htaccess}]
 indent_style = tab

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -66,74 +66,74 @@ parameters:
 			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeFlex.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedBeUsers\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeFolder\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedBeUsers.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedBeUsers\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeFolder\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedBeUsers.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedBeUsersBeGroups\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedBeUsers\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedBeUsersBeGroups.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedBeUsersBeGroups\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedBeUsers\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedBeUsersBeGroups.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedPages\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedBeUsersBeGroups\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedPages.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedPages\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedBeUsersBeGroups\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedPages.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedStaticdata\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedPages\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedStaticdata.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedStaticdata\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedPages\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedStaticdata.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedSysFiles\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedStaticdata\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedSysFiles.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbAllowedSysFiles\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedStaticdata\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbAllowedSysFiles.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbFal\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedSysFiles\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbFal.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupDbFal\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupAllowedSysFiles\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupDbFal.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
 
 		-
-			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupFolder\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupFal\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupFolder.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
 
 		-
-			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupFolder\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
+			message: "#^Property TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeGroupFal\\:\\:\\$matchArray type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupFolder.php
+			path: ../Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
 
 		-
 			message: "#^Method TYPO3\\\\CMS\\\\Styleguide\\\\TcaDataGenerator\\\\FieldGenerator\\\\TypeImageManipulation\\:\\:generate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
@@ -21,9 +21,9 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGeneratorInterface;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 
 /**
- * Generate data for type=group fields
+ * Generate data for type=folder fields
  */
-class TypeGroupDbAllowedStaticdata extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeFolder extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array General match if type=group
@@ -31,8 +31,7 @@ class TypeGroupDbAllowedStaticdata extends AbstractFieldGenerator implements Fie
     protected $matchArray = [
         'fieldConfig' => [
             'config' => [
-                'type' => 'group',
-                'allowed' => 'tx_styleguide_staticdata',
+                'type' => 'folder',
             ],
         ],
     ];
@@ -47,8 +46,7 @@ class TypeGroupDbAllowedStaticdata extends AbstractFieldGenerator implements Fie
     {
         /** @var RecordFinder $recordFinder */
         $recordFinder = GeneralUtility::makeInstance(RecordFinder::class);
-        $staticdataUids = $recordFinder->findUidsOfStaticdata();
-        // Return only one element
-        return (string)current($staticdataUids);
+        $folder = $recordFinder->findDemoFolderObject();
+        return $folder->getCombinedIdentifier();
     }
 }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupDbAllowedBeUsersBeGroups extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupAllowedBeUsers extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array General match if type=group
@@ -32,7 +32,7 @@ class TypeGroupDbAllowedBeUsersBeGroups extends AbstractFieldGenerator implement
         'fieldConfig' => [
             'config' => [
                 'type' => 'group',
-                'allowed' => 'be_users,be_groups',
+                'allowed' => 'be_users',
             ],
         ],
     ];
@@ -47,15 +47,6 @@ class TypeGroupDbAllowedBeUsersBeGroups extends AbstractFieldGenerator implement
     {
         /** @var RecordFinder $recordFinder */
         $recordFinder = GeneralUtility::makeInstance(RecordFinder::class);
-        $beGroupUids = $recordFinder->findUidsOfDemoBeGroups();
-        $beUserUids = $recordFinder->findUidsOfDemoBeUsers();
-        $result = [];
-        foreach ($beGroupUids as $uid) {
-            $result[] = 'be_groups_' . $uid;
-        }
-        foreach ($beUserUids as $uid) {
-            $result[] = 'be_users_' . $uid;
-        }
-        return implode(',', $result);
+        return implode(',', $recordFinder->findUidsOfDemoBeUsers());
     }
 }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupDbAllowedBeUsers extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupAllowedBeUsersBeGroups extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array General match if type=group
@@ -32,7 +32,7 @@ class TypeGroupDbAllowedBeUsers extends AbstractFieldGenerator implements FieldG
         'fieldConfig' => [
             'config' => [
                 'type' => 'group',
-                'allowed' => 'be_users',
+                'allowed' => 'be_users,be_groups',
             ],
         ],
     ];
@@ -47,6 +47,15 @@ class TypeGroupDbAllowedBeUsers extends AbstractFieldGenerator implements FieldG
     {
         /** @var RecordFinder $recordFinder */
         $recordFinder = GeneralUtility::makeInstance(RecordFinder::class);
-        return implode(',', $recordFinder->findUidsOfDemoBeUsers());
+        $beGroupUids = $recordFinder->findUidsOfDemoBeGroups();
+        $beUserUids = $recordFinder->findUidsOfDemoBeUsers();
+        $result = [];
+        foreach ($beGroupUids as $uid) {
+            $result[] = 'be_groups_' . $uid;
+        }
+        foreach ($beUserUids as $uid) {
+            $result[] = 'be_users_' . $uid;
+        }
+        return implode(',', $result);
     }
 }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupDbAllowedPages extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupAllowedPages extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array Match if type=group and allowed=pages

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupFolder extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupAllowedStaticdata extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array General match if type=group
@@ -32,7 +32,7 @@ class TypeGroupFolder extends AbstractFieldGenerator implements FieldGeneratorIn
         'fieldConfig' => [
             'config' => [
                 'type' => 'group',
-                'internal_type' => 'folder',
+                'allowed' => 'tx_styleguide_staticdata',
             ],
         ],
     ];
@@ -47,7 +47,8 @@ class TypeGroupFolder extends AbstractFieldGenerator implements FieldGeneratorIn
     {
         /** @var RecordFinder $recordFinder */
         $recordFinder = GeneralUtility::makeInstance(RecordFinder::class);
-        $folder = $recordFinder->findDemoFolderObject();
-        return $folder->getCombinedIdentifier();
+        $staticdataUids = $recordFinder->findUidsOfStaticdata();
+        // Return only one element
+        return (string)current($staticdataUids);
     }
 }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupDbAllowedSysFiles extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupAllowedSysFiles extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array Match if type=group and allowed=pages

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\RecordFinder;
 /**
  * Generate data for type=group fields
  */
-class TypeGroupDbFal extends AbstractFieldGenerator implements FieldGeneratorInterface
+class TypeGroupFal extends AbstractFieldGenerator implements FieldGeneratorInterface
 {
     /**
      * @var array General match if type=group

--- a/Classes/TcaDataGenerator/FieldGeneratorResolver.php
+++ b/Classes/TcaDataGenerator/FieldGeneratorResolver.php
@@ -86,13 +86,15 @@ class FieldGeneratorResolver
         FieldGenerator\TypeUser::class,
 
         // type=group
-        FieldGenerator\TypeGroupDbFal::class,
-        FieldGenerator\TypeGroupDbAllowedBeUsersBeGroups::class,
-        FieldGenerator\TypeGroupDbAllowedBeUsers::class,
-        FieldGenerator\TypeGroupDbAllowedStaticdata::class,
-        FieldGenerator\TypeGroupDbAllowedPages::class,
-        FieldGenerator\TypeGroupDbAllowedSysFiles::class,
-        FieldGenerator\TypeGroupFolder::class,
+        FieldGenerator\TypeGroupFal::class,
+        FieldGenerator\TypeGroupAllowedBeUsersBeGroups::class,
+        FieldGenerator\TypeGroupAllowedBeUsers::class,
+        FieldGenerator\TypeGroupAllowedStaticdata::class,
+        FieldGenerator\TypeGroupAllowedPages::class,
+        FieldGenerator\TypeGroupAllowedSysFiles::class,
+
+        // type=folder
+        FieldGenerator\TypeFolder::class,
 
         // type=select
         FieldGenerator\TypeSelectRenderTypeSingleForeignTable::class,

--- a/Configuration/TCA/tx_styleguide_elements_folder.php
+++ b/Configuration/TCA/tx_styleguide_elements_folder.php
@@ -1,0 +1,188 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Form engine elements - folder',
+        'label' => 'uid',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'iconfile' => 'EXT:styleguide/Resources/Public/Icons/tx_styleguide.svg',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+    ],
+
+    'columns' => [
+
+        'hidden' => [
+            'exclude' => 1,
+            'config' => [
+                'type' => 'check',
+                'items' => [
+                    ['Disable'],
+                ],
+            ],
+        ],
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        '',
+                        0,
+                    ],
+                ],
+                'foreign_table' => 'tx_styleguide_elements_folder',
+                'foreign_table_where' => 'AND {#tx_styleguide_elements_folder}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_folder}.{#sys_language_uid} IN (-1,0)',
+                'default' => 0,
+            ],
+        ],
+        'l10n_source' => [
+            'exclude' => true,
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation source',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        '',
+                        0,
+                    ],
+                ],
+                'foreign_table' => 'tx_styleguide_elements_folder',
+                'foreign_table_where' => 'AND {#tx_styleguide_elements_folder}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_elements_folder}.{#uid}!=###THIS_UID###',
+                'default' => 0,
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+
+        'folder_1' => [
+            'exclude' => 1,
+            'label' => 'folder_1 description',
+            'description' => 'field description',
+            'config' => [
+                'type' => 'folder',
+            ],
+        ],
+
+        'folder_2' => [
+            'exclude' => 1,
+            'label' => 'folder_2 hideMoveIcons=true',
+            'description' => 'field description',
+            'config' => [
+                'type' => 'folder',
+                'hideMoveIcons' => true,
+            ],
+        ],
+
+        'flex_1' => [
+            'exclude' => 1,
+            'label' => 'flex_1',
+            'config' => [
+                'type' => 'flex',
+                'ds' => [
+                    'default' => '
+                        <T3DataStructure>
+                            <sheets>
+
+                                <sDb>
+                                    <ROOT>
+                                        <type>array</type>
+                                        <TCEforms>
+                                            <sheetTitle>folder</sheetTitle>
+                                        </TCEforms>
+                                        <el>
+                                            <folder_1>
+                                                <TCEforms>
+                                                    <label>folder_1 description</label>
+                                                    <description>field description</description>
+                                                    <config>
+                                                        <type>folder</type>
+                                                    </config>
+                                                </TCEforms>
+                                            </folder_1>
+                                        </el>
+                                    </ROOT>
+                                </sDb>
+
+                                <sSection>
+                                    <ROOT>
+                                        <type>array</type>
+                                        <TCEforms>
+                                            <sheetTitle>section</sheetTitle>
+                                        </TCEforms>
+                                        <el>
+                                            <section_1>
+                                                <title>section_1</title>
+                                                <type>array</type>
+                                                <section>1</section>
+                                                <el>
+                                                    <container_1>
+                                                        <type>array</type>
+                                                        <title>container_1</title>
+                                                        <el>
+                                                            <folder_1>
+                                                                <TCEforms>
+                                                                    <label>folder_1</label>
+                                                                    <config>
+                                                                        <type>folder</type>
+                                                                        <size>5</size>
+                                                                    </config>
+                                                                </TCEforms>
+                                                            </folder_1>
+                                                        </el>
+                                                    </container_1>
+                                                </el>
+                                            </section_1>
+                                        </el>
+                                    </ROOT>
+                                </sSection>
+
+                            </sheets>
+                        </T3DataStructure>
+                    ',
+                ],
+            ],
+        ],
+
+    ],
+
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;type=folder,
+                    folder_1, folder_2,
+                --div--;in flex,
+                    flex_1,
+                --div--;meta,
+                disable, sys_language_uid, l10n_parent, l10n_source,
+            ',
+        ],
+    ],
+
+];

--- a/Configuration/TCA/tx_styleguide_elements_group.php
+++ b/Configuration/TCA/tx_styleguide_elements_group.php
@@ -207,16 +207,6 @@ return [
             ],
         ],
 
-        'group_folder_1' => [
-            'exclude' => 1,
-            'label' => 'group_folder_1 desription',
-            'description' => 'field description',
-            'config' => [
-                'type' => 'group',
-                'internal_type' => 'folder',
-            ],
-        ],
-
         'group_requestUpdate_1' => [
             'exclude' => 1,
             'label' => 'group_requestUpdate_1',
@@ -335,10 +325,8 @@ return [
     'types' => [
         '0' => [
             'showitem' => '
-                --div--;db,
+                --div--;type=group,
                     group_db_1, group_db_2, group_db_9, group_db_3, group_db_8, group_db_11, group_db_4, group_db_5, group_db_7, group_db_10,
-                --div--;internal_type=folder,
-                    group_folder_1,
                 --div--;in flex,
                     flex_1,
                 --div--;requestUpdate,

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -66,6 +66,7 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_styleguide_custom'] =
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_basic');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_group');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_folder');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_imagemanipulation');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_rte');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_styleguide_elements_rte_inline_1_child');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -199,12 +199,17 @@ CREATE TABLE tx_styleguide_elements_group (
     group_db_9 text,
     group_db_10 text,
     group_db_11 text,
-    group_folder_1 text,
     group_requestUpdate_1 text,
 
     flex_1 text
 );
 
+CREATE TABLE tx_styleguide_elements_folder
+(
+    folder_1 text,
+    folder_2 text,
+    flex_1 text
+);
 
 CREATE TABLE tx_styleguide_elements_imagemanipulation (
     group_db_1 text,


### PR DESCRIPTION
As a result of:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/73622

internal_type=folder is now an own type (=folder).

Also editorconfig is adjusted to the current style.

Releases: main