### PR TITLE
[TASK] Fix outdated TYPO3 installation documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Presents supported styles for TYPO3 backend modules.
 This Styleguide comes as a TYPO3 extension for the TYPO3 backend. It appears as backend module within the Help/Manuals navigation section.
 
 ## Composer
-With composer based [TYPO3 installation](https://wiki.typo3.org/Composer) add this Styleguide by running the following command on shell within project root (where the root composer.json file resides):
+With composer based [TYPO3 installation](https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/QuickInstall/Composer/Index.html) add this Styleguide by running the following command on shell within project root (where the root composer.json file resides):
 
 ```
 composer require --dev typo3/cms-styleguide


### PR DESCRIPTION
See https://github.com/TYPO3-Documentation/T3DocTeam/issues/170 for details.