### PR TITLE
[TASK] Fix outdated TYPO3 installation documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ to let styleguide create an example page tree with records by clicking the
 seconds for the system to crunch the data.
 
 ## Composer
-With [composer based](https://docs.typo3.org/m/typo3/guide-installation/master/en-us/QuickInstall/Composer/Index.html)
+With [composer based](https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Installation/Install.html)
 TYPO3 installations, styleguide is easily added to the project.
 
 TYPO3 v11 based project:


### PR DESCRIPTION
See https://github.com/TYPO3-Documentation/T3DocTeam/issues/170 for details.