### PR TITLE
[BUGFIX] Avoid deprecated TCA eval option "required"

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -417,7 +417,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon --no-progress --no-interaction
       "
 
   phpstan_generate_baseline:
@@ -433,7 +433,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon --generate-baseline=Build/phpstan-baseline.neon
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon --no-progress --no-interaction --generate-baseline=Build/phpstan-baseline.neon
       "
 
   unit:

--- a/Configuration/TCA/tx_styleguide_ctrl_common.php
+++ b/Configuration/TCA/tx_styleguide_ctrl_common.php
@@ -107,7 +107,8 @@ return [
            'config' => [
                'type' => 'input',
                'width' => 200,
-               'eval' => 'trim,required',
+               'eval' => 'trim',
+               'required' => true,
            ],
        ],
        'description' => [

--- a/Configuration/TCA/tx_styleguide_inline_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm.php
@@ -82,7 +82,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_mm_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_child.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'parents' => [

--- a/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'parents' => [

--- a/Configuration/TCA/tx_styleguide_inline_mn.php
+++ b/Configuration/TCA/tx_styleguide_inline_mn.php
@@ -82,7 +82,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_mn_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mn_child.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'parents' => [

--- a/Configuration/TCA/tx_styleguide_inline_mngroup.php
+++ b/Configuration/TCA/tx_styleguide_inline_mngroup.php
@@ -82,7 +82,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'inline_1' => [

--- a/Configuration/TCA/tx_styleguide_inline_mngroup_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mngroup_child.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'parents' => [

--- a/Configuration/TCA/tx_styleguide_inline_mnsymmetric.php
+++ b/Configuration/TCA/tx_styleguide_inline_mnsymmetric.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'branches' => [

--- a/Configuration/TCA/tx_styleguide_inline_mnsymmetricgroup.php
+++ b/Configuration/TCA/tx_styleguide_inline_mnsymmetricgroup.php
@@ -83,7 +83,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => '30',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'branches' => [

--- a/Configuration/TCA/tx_styleguide_required.php
+++ b/Configuration/TCA/tx_styleguide_required.php
@@ -91,7 +91,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'max' => 23,
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'input_2' => [
@@ -100,7 +100,8 @@ return [
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
-                'eval' => 'trim,required,date',
+                'eval' => 'trim,date',
+                'required' => true,
             ],
         ],
         'input_3' => [
@@ -110,7 +111,8 @@ return [
                 'type' => 'input',
                 'renderType' => 'inputLink',
                 'size' => 60,
-                'eval' => 'trim,required',
+                'eval' => 'trim',
+                'required' => true,
             ],
         ],
 
@@ -119,7 +121,7 @@ return [
             'label' => 'text_1 eval=required',
             'config' => [
                 'type' => 'text',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
 
@@ -240,10 +242,10 @@ return [
             'label' => 'rte_1 eval=required',
             'config' => [
                 'type' => 'text',
-                'eval' => 'required',
                 'rows' => '15',
                 'cols' => '80',
                 'enableRichtext' => true,
+                'required' => true,
             ],
         ],
         'rte_2' => [
@@ -412,7 +414,7 @@ return [
             'label' => 'palette_input_1 eval=required',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
         'palette_input_2' => [
@@ -420,7 +422,7 @@ return [
             'label' => 'palette_input_2 eval=required',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_required_flex_2_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_required_flex_2_inline_1_child.php
@@ -87,7 +87,7 @@ return [
             'label' => 'input_1 eval=required',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_required_inline_2_child.php
+++ b/Configuration/TCA/tx_styleguide_required_inline_2_child.php
@@ -87,7 +87,7 @@ return [
             'label' => 'input_1',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_required_inline_3_child.php
+++ b/Configuration/TCA/tx_styleguide_required_inline_3_child.php
@@ -87,7 +87,7 @@ return [
             'label' => 'input_1',
             'config' => [
                 'type' => 'input',
-                'eval' => 'required',
+                'required' => true,
             ],
         ],
 

--- a/Configuration/TCA/tx_styleguide_required_rte_2_child.php
+++ b/Configuration/TCA/tx_styleguide_required_rte_2_child.php
@@ -87,8 +87,8 @@ return [
             'label' => 'rte_1',
             'config' => [
                 'type' => 'text',
-                'eval' => 'required',
                 'enableRichtext' => true,
+                'required' => true,
             ],
         ],
 


### PR DESCRIPTION
Pull request contains two commits


**[BUGFIX] Avoid deprecated TCA eval option "required"**

This change adopts the corresponding TCA definition
changes to avoid the TCA auto migration warning and
github ci failures.

See: https://forge.typo3.org/issues/97035

Releases: main


and 

**[TASK] Add options "--no-progress --no-interaction" to phpstan commands**

backport of provided with https://github.com/TYPO3/styleguide/pull/300 .