### PR TITLE
[TASK] Replace deprecated ExpressionBuilder methods and CompositeExpression usage

### DIFF
--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -282,7 +282,7 @@ class RecordFinder
 
             if (!empty($doktype)) {
                 $queryBuilder->orWhere(
-                    $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->and(
                         $queryBuilder->expr()->eq(
                             'tx_styleguide_containsdemo',
                             $queryBuilder->createNamedParameter((string)$type),
@@ -334,11 +334,11 @@ class RecordFinder
             );
 
         if (!empty($types)) {
-            $orX = $queryBuilder->expr()->orX();
+            $orExpression = $queryBuilder->expr()->or();
             foreach ($types as $type) {
-                $orX->add($queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter($type)));
+                $orExpression = $orExpression->with($queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter($type)));
             }
-            $queryBuilder->andWhere((string)$orX);
+            $queryBuilder->andWhere((string)$orExpression);
         }
 
         return $queryBuilder->orderBy('uid', 'DESC')->execute()->fetchAllAssociative();


### PR DESCRIPTION
**doctrine/dbal** changed the way some methods in **ExpressionBuilder** works
and is transforming **CompositeExpression** in a inmutable class design. Core try
to keep up with upstream **doctrine/dbal** changes and introduced the new way
**doctrine/dbal** is favorizing.

This change adopts these early changes to be prepared when core is adding
deprecations for these methods.

* `ExpressionBuilder->andX(...)` to `ExpressionBuilder->and(...)`
* `ExpressionBuilder->orX(...)` to `ExpressionBuilder->or(...)`
* `CompositeExpression->add(...)` with immutable `$ce = $ce->with(...)`

Related preparation core patches:

* https://review.typo3.org/c/Packages/TYPO3.CMS/+/73765
* https://review.typo3.org/c/Packages/TYPO3.CMS/+/73817

**Releases**: main