### PR TITLE
[TASK] Replace deprecated QueryBuilder->execute()

### DIFF
--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -303,7 +303,7 @@ class RecordFinder
             }
         }
 
-        $rows = $queryBuilder->orderBy('pid', 'DESC')->execute()->fetchAllAssociative();
+        $rows = $queryBuilder->orderBy('pid', 'DESC')->executeQuery()->fetchAllAssociative();
         $result = [];
         if (is_array($rows)) {
             $result = array_column($rows, 'uid');
@@ -341,7 +341,7 @@ class RecordFinder
             $queryBuilder->andWhere((string)$orExpression);
         }
 
-        return $queryBuilder->orderBy('uid', 'DESC')->execute()->fetchAllAssociative();
+        return $queryBuilder->orderBy('uid', 'DESC')->executeQuery()->fetchAllAssociative();
     }
 
     public function findFeUserGroups(): array
@@ -357,7 +357,7 @@ class RecordFinder
                 )
             );
 
-        return $queryBuilder->orderBy('uid', 'DESC')->execute()->fetchAllAssociative();
+        return $queryBuilder->orderBy('uid', 'DESC')->executeQuery()->fetchAllAssociative();
     }
 
     public function findFeUsers(): array
@@ -373,6 +373,6 @@ class RecordFinder
                 )
             );
 
-        return $queryBuilder->orderBy('uid', 'DESC')->execute()->fetchAllAssociative();
+        return $queryBuilder->orderBy('uid', 'DESC')->executeQuery()->fetchAllAssociative();
     }
 }


### PR DESCRIPTION
TYPO3 v12 has deprecated the `QueryBuilder->execute()`
method to align with corresponding deprecation of the
used doctrine/dbal package with:

ISSUE: https://forge.typo3.org/issues/96972
PATCH: https://review.typo3.org/c/Packages/TYPO3.CMS/+/73610

This has been prepared in this repository with 6b2bf56,
however some places have been missed, which are now properly
replaced.

Releases: main