### PR TITLE
[BUGFIX] Fix mixed-up valuePicker values/labels

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -337,10 +337,10 @@ return [
                 'eval' => 'trim',
                 'valuePicker' => [
                     'items' => [
-                        [ 'spring', 'Spring'],
-                        [ 'summer', 'Summer'],
-                        [ 'autumn', 'Autumn'],
-                        [ 'winter', 'Winter'],
+                        ['Spring', 'spring'],
+                        ['Summer', 'summer'],
+                        ['Autumn', 'autumn'],
+                        ['Winter', 'winter'],
                     ],
                 ],
             ],
@@ -355,10 +355,10 @@ return [
                 'valuePicker' => [
                     'mode' => 'append',
                     'items' => [
-                        [ 'spring', 'Spring'],
-                        [ 'summer', 'Summer'],
-                        [ 'autumn', 'Autumn'],
-                        [ 'winter', 'Winter'],
+                        ['Spring', 'spring'],
+                        ['Summer', 'summer'],
+                        ['Autumn', 'autumn'],
+                        ['Winter', 'winter'],
                     ],
                 ],
             ],
@@ -373,10 +373,10 @@ return [
                 'valuePicker' => [
                     'mode' => 'prepend',
                     'items' => [
-                        [ 'spring', 'Spring'],
-                        [ 'summer', 'Summer'],
-                        [ 'autumn', 'Autumn'],
-                        [ 'winter', 'Winter'],
+                        ['Spring', 'spring'],
+                        ['Summer', 'summer'],
+                        ['Autumn', 'autumn'],
+                        ['Winter', 'winter'],
                     ],
                 ],
             ],

--- a/Configuration/TCA/tx_styleguide_inline_1n_inline_1_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1n_inline_1_child.php
@@ -99,9 +99,9 @@ return [
                 'size' => 10,
                 'valuePicker' => [
                     'items' => [
-                        [ 'blue', '#0000FF'],
-                        [ 'red', '#FF0000'],
-                        [ 'typo3 orange', '#FF8700'],
+                        ['blue', '#0000FF'],
+                        ['red', '#FF0000'],
+                        ['typo3 orange', '#FF8700'],
                     ],
                 ],
             ],


### PR DESCRIPTION
Key 0 is the label and key 1 is the value.
This was wrong for the seasons.

Releases: main, 11.5