### PR TITLE
[DOCS] Align with new TYPO3 documentation standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# TS/JS-Files
+# JS/TS-Files
 [*.{ts,js}]
 indent_size = 2
 
@@ -20,13 +20,18 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
-# YAML-Files
-[*.{yaml,yml}]
-indent_size = 2
+# MD-Files
+[*.md]
+max_line_length = 80
 
 # NEON-Files
 [*.neon]
 indent_size = 2
+
+# ReST-Files
+[*.{rst,rst.txt}]
+indent_size = 3
+max_line_length = 80
 
 # TypoScript
 [*.{typoscript,tsconfig}]
@@ -35,6 +40,10 @@ indent_size = 2
 # XLF-Files
 [*.xlf]
 indent_style = tab
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2
 
 # .htaccess
 [{_.htaccess,.htaccess}]

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Build/testing-docker/.env
 composer.lock
 Tests/Acceptance/Support/_generated/
 .sass-cache/
+/Documentation-GENERATED-temp/

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,0 +1,35 @@
+.. More information about this file:
+.. https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
+
+.. ----------
+.. text roles
+.. ----------
+
+.. role:: aspect(emphasis)
+.. role:: bash(code)
+.. role:: css(code)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: rst(code)
+.. role:: sep(strong)
+.. role:: sql(code)
+
+.. role:: tsconfig(code)
+   :class: typoscript
+
+.. role:: typoscript(code)
+.. role:: xml(code)
+   :class: html
+
+.. role:: yaml(code)
+
+.. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks use PHP syntax highlighting
+
+.. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,21 +1,174 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.rst.txt
 
-.. _start:
+================
+TYPO3 Styleguide
+================
 
-==========
-Styleguide
-==========
+:Extension key:
+   styleguide
 
-:Extension key: styleguide
-:Version: |release|
-:Language: en
-:Description: TYPO3 CMS Backend Styleguide for supported styles of TYPO3 Backend modules
-:Author: TYPO3 CMS Core Development Team
-:Rendered: |today|
+:Package name:
+   typo3/cms-styleguide
 
-Welcome to the living Styleguide for TYPO3 CMS backend. There is not that much to tell here,
-please find valuable information about this extension in the README.md file on
-`github <https://github.com/TYPO3/styleguide/>`_
+:Version:
+   |release|
+
+:Language:
+   en
+
+:Author:
+   TYPO3 Core Team
+
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
+:Rendered:
+   |today|
+
+----
+
+This style guide is a showcase for many TYPO3 backend features that are useful
+for developing your own extensions:
+
+* A number of snippets showing how to use standard backend UI elements like
+  tables, buttons, boxes or notifications.
+* A large number of examples of backend edit forms, showing many features of the
+  :doc:`TCA <t3tca:Index>`.
+
+It provides a backend module that hooks into the 'help' menu of the top toolbar
+of the backend and can also create a page tree to show examples.
+
+This extension is being developed close to core: Additions and deprecations of
+TYPO3 core features used in this extension will be considered here in a timely
+manner.
+
+----
+
+**Table of Contents:**
+
+.. contents::
+   :backlinks: top
+   :depth: 1
+   :local:
+
+
+Usages
+======
+
+*  The extension is interesting for **backend extension developers** as a
+   reference to see how casual stuff like buttons and other HTML related things
+   are solved or used in the backend, and to copy+paste solutions. In addition,
+   the TCA examples are a nearly complete show case of the
+   :ref:`Form Engine <t3coreapi:FormEngine>` (editing records in the backend).
+   Developers will see new things they didn't know before. Guaranteed!
+
+*  The extension may be of interest to **technical project managers** to get an
+   idea of what backend editing can do "out-of-the-box" and what parts can be
+   sold to customers without imposing expensive implementation burdens on
+   developers.
+
+*  Styleguide is a require-dev dependency of the
+   `TYPO3 mono repository <https://github.com/typo3/typo3>`__. It is used by
+   **core developers** to test changes to JavaScript, HTML, and PHP code to
+   verify that the layout or functionality of backend modules is not affected.
+   The extension is also used in core acceptance tests to verify that Form
+   Engine details are not broken during core patch development.
+
+*  The style guide is used in the official TYPO3 documentation to provide
+   examples, screenshots and possible uses of core features. In particular, the
+   :doc:`TCA reference <t3tca:Index>` relies heavily on it.
+
+*  Styleguide comes with a simple setup of unit, functional and acceptance tests
+   that are executed locally or via the GitHub workflow "tests.yml". They
+   can be used as copy+paste boilerplate in custom extensions. Furthermore,
+   these test setups serve as the basis of the
+   :ref:`testing pages <t3coreapi:testing>` of the official TYPO3 documentation.
+
+
+Installation
+============
+
+Styleguide is a TYPO3 extension for the TYPO3 backend. It appears as a backend
+module in the "Help" section of the top toolbar. After the initial installation
+it is advisable to let Styleguide create a sample page tree with records by
+clicking on the button "TCA / records -> Create styleguide page tree with data"
+and wait a few seconds until the system has processed the data.
+
+Composer
+--------
+
+With :ref:`composer based <t3start:install>` TYPO3 installations, Styleguide is
+easily added to the project.
+
+TYPO3 v11 based project:
+
+.. code-block:: bash
+
+   composer require --dev typo3/cms-styleguide:^11
+
+TYPO3 v10 based project:
+
+.. code-block:: bash
+
+   composer require --dev typo3/cms-styleguide:^10
+   bin/typo3 extension:activate styleguide
+
+TYPO3 Extension Repository
+--------------------------
+
+For non-composer projects, the extension is available in the TER under the
+extension key `styleguide` and can be installed via the Extension Manager.
+
+
+Running tests
+=============
+
+Styleguide comes with a simple demo set of unit, functional and acceptance tests.
+It relies on the runTests.sh script which is a simplified version of a similar
+script from the TYPO3 core. Find detailed usage examples by executing
+
+.. code-block:: bash
+
+   Build/Scripts/runTests.sh -h
+
+and have a look at :file:`.github/workflows/tests.yml` to see how this is used
+in CI.
+
+Example usage:
+
+.. code-block:: bash
+
+   Build/Scripts/runTests.sh -s composerUpdate
+   Build/Scripts/runTests.sh -s unit
+
+
+Tagging and releasing
+=====================
+
+The package available on `Packagist <https://packagist.org/packages/typo3/cms-styleguide>`__
+is updated via the implemented Github hook. Releases in the TER are created by
+the Github workflow "publish.yml" if a commit with a release tag was previously
+marked with `Tailor <https://github.com/TYPO3/tailor>`__. The message of the
+commit is used as TER upload comment.
+
+Example:
+
+.. code-block:: bash
+
+   composer install
+   .Build/bin/tailor set-version 11.0.3
+   git commit -am "[RELEASE] 11.0.3 Bug fixes and improved core v11 compatibility"
+   git tag 11.0.3
+   git push
+   git push --tags
+
+
+Legal
+=====
+
+This project is released under GPLv2+ license. See LICENSE.txt for details.
+
+* The "tree" icon is from `Yusuke Kamiyamane <https://p.yusukekamiyamane.com/>`__.
+* Placeholder texts are from `Bacon Ipsum <https://baconipsum.com/>`__.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,3 +1,67 @@
+# More information about this file:
+# https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#settings-cfg
+
 [general]
 
-project = Styleguide
+project     = TYPO3 Styleguide
+version     = main (development)
+release     = main (development)
+copyright   = since 2013 by the TYPO3 Core Team & Contributors
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+github_repository    = TYPO3/styleguide
+github_branch        = main
+
+# Footer links
+project_home         = https://extensions.typo3.org/extension/styleguide/
+project_contact      = https://typo3.slack.com/archives/C03AM9R17
+project_repository   = https://github.com/TYPO3/styleguide
+project_issues       = https://github.com/TYPO3/styleguide/issues
+project_discussions  =
+
+use_opensearch       =
+
+[intersphinx_mapping]
+
+# Official TYPO3 manuals
+# h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+# t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+# t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
+# t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
+t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/main/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
+# t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+# ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
+# ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
+# ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
+# ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/

--- a/README.md
+++ b/README.md
@@ -1,125 +1,28 @@
-![tests](https://github.com/TYPO3/styleguide/workflows/tests/badge.svg)
+[![Latest Stable Version](https://poser.pugx.org/typo3/cms-styleguide/v/stable)](https://extensions.typo3.org/extension/styleguide/)
+[![TYPO3 12-dev](https://img.shields.io/badge/TYPO3-12--dev-orange.svg?style=flat-square)](https://github.com/typo3/typo3)
+[![Total Downloads](https://poser.pugx.org/typo3/cms-styleguide/d/total)](https://packagist.org/packages/typo3/cms-styleguide)
+[![Monthly Downloads](https://poser.pugx.org/typo3/cms-styleguide/d/monthly)](https://packagist.org/packages/typo3/cms-styleguide)
+[![Tests](https://github.com/TYPO3/styleguide/workflows/tests/badge.svg)](https://github.com/TYPO3/styleguide/actions/workflows/tests.yml)
 
-TYPO3 CMS Backend Styleguide
-============================
+# TYPO3 extension `styleguide`
 
-![](Documentation/styleguide_index.png)
+This style guide is a showcase for many TYPO3 backend features that are useful
+for developing your own extensions:
 
-
-# What is it?
-
-Styleguide is a TYPO3 extension. It provides a backend module that hooks
-into the 'Help' menu of the top toolbar of the TYPO3 Backend. It can also create a
-page tree to show examples.
-
-This extension in maintained in the official [TYPO3 github organization.](https://github.com/TYPO3/styleguide)
-
-Styleguide is developed "core-near": When TYPO3 core adds or deprecates features
-covered by this extension, core developers strive to keep it updated, reflecting
-these changes.
-
-Styleguide is a reference to show a lot of TYPO3 backend features, often relevant
-for own extensions:
-
-* A set of snippets showing how to use default backend functionality like
+* A number of snippets showing how to use standard backend UI elements like
   tables, buttons, boxes or notifications.
-* A huge set of 'TCA' examples, showing "all" features of the backend editing forms.
+* A large number of examples of backend edit forms, showing many features of the
+  [TCA](https://docs.typo3.org/m/typo3/reference-tca/main/en-us/).
 
+It provides a backend module that hooks into the 'help' menu of the top toolbar
+of the backend and can also create a page tree to show examples.
 
-# Usages
+This extension is being developed close to core: Additions and deprecations of
+TYPO3 core features used in this extension will be considered here in a timely
+manner.
 
-* The extension is interesting for **backend extension developers** as a reference
-  to see how casual stuff like buttons and other HTML related things are solved or
-  used in the backend, and to copy+paste solutions. Additionally, the TCA examples
-  is a near-complete show-case of [FormEngine](https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/FormEngine/Index.html)
-  (editing records in the backend). Developers will see new things they did not
-  know yet. Guaranteed!
-
-* The extension can be interesting for **technical project managers** to get an idea
-  of what the backend editing is capable of out-of-the-box and which parts can be
-  sold to customers without adding expensive implementation burdens to developers.
-
-* Styleguide is a "require-dev" dependency of the [TYPO3 CMS core mono repository](https://github.com/typo3/typo3).
-  It is used by **core developers** to test and verify changes to JavaScript, HTML
-  and PHP code do not break layout or functionality of backend modules. The extension
-  is also used in core backend acceptance tests to verify FormEngine details do not
-  break when developing core patches.
-
-* Styleguide is used within the official core documentation to provide examples, screenshots
-  and possible usages of core functionality. Especially the [TCA reference](https://docs.typo3.org/m/typo3/reference-tca/master/en-us/)
-  heavily relies on it.
-
-* Styleguide comes with a simple set up of unit, functional and acceptance tests that
-  are executed by github action workflow "tests.yml" - or locally if desired. This setup
-  is documented as a working test set up example within the official [TYPO3 explained testing section](https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Testing/Index.html)
-  and can be used as a copy+paste boilerplate in own extensions.
-
-# Installation
-
-Styleguide comes as a TYPO3 extension for the TYPO3 backend. It appears as backend module
-within the "Help" section of the top toolbar. After initial installation, it is advisable
-to let styleguide create an example page tree with records by clicking the
-"TCA / records -> Create styleguide page tree with data", and waiting for a couple of
-seconds for the system to crunch the data.
-
-## Composer
-With [composer based](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html)
-TYPO3 installations, styleguide is easily added to the project.
-
-TYPO3 v11 based project:
-
-```
-composer require --dev typo3/cms-styleguide:^11
-```
-
-TYPO3 v10 based project:
-
-```
-composer require --dev typo3/cms-styleguide:^10
-bin/typo3 extension:activate styleguide
-```
-
-## TYPO3 Extension Repository
-For non-composer projects, the extension is available in TER as extension key `styleguide` and can
-be installed using the extension manager.
-
-
-# Running tests
-
-Styleguide comes with a simple demo set of unit, functional and acceptance tests. It relies
-on the runTests.sh script which is a simplified version of a similar script from the TYPO3 core.
-Find detailed usage examples by executing `Build/Scripts/runTests.sh -h` and have a look at
-`.github/workflows/tests.yml` to see how this is used in CI.
-
-Example usage:
-
-```
-Build/Scripts/runTests.sh -s composerUpdate
-Build/Scripts/runTests.sh -s unit
-```
-
-
-# Tagging and releasing
-
-[packagist.org](https://packagist.org/packages/typo3/cms-styleguide) is enabled via the casual github hook.
-TER releases are created by the "publish.yml" github workflow when tagging versions
-using [tailor](https://github.com/TYPO3/tailor). The commit message of the commit a tag points to is
-used as TER upload comment.
-
-Example:
-
-```
-composer install
-.Build/bin/tailor set-version 11.0.3
-git commit -am "[RELEASE] 11.0.3 Bug fixes and improved core v11 compatibility"
-git tag 11.0.3
-git push
-git push --tags
-```
-
-
-# Legal
-This project is released under GPLv2 license. See LICENSE.txt for details.
-
-* The "tree" icon is from [Yusuke Kamiyamane](http://p.yusukekamiyamane.com/)
-* Placeholder texts are from [Bacon Ipsum](http://baconipsum.com/)
+|                  | URL                                                       |
+|------------------|-----------------------------------------------------------|
+| **Repository:**  | https://github.com/TYPO3/styleguide                       |
+| **Read online:** | https://docs.typo3.org/p/typo3/cms-styleguide/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/styleguide/        |


### PR DESCRIPTION
Hi Lolli, hi TYPO3 Core Team,

this PR is a suggestion to align your extension documentation with the recently introduced [TYPO3 documentation standards](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html) and similar extensions.

The focus is on having one central documentation at Documentation/ and reduce the README to an abstract, badges and further links to all important aspects of the extensions (TER, docs, VCS). To match your specific needs i kept the single file documentation approach by moving the README.md completely into the Index.rst. 

Greetings, Alex

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185