### PR TITLE
[BUGFIX] Include TypoScript constants of indexed_search in frontend site configuration (11)

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,1 +1,2 @@
 @import 'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript'
+@import 'EXT:indexed_search/Configuration/TypoScript/constants.typoscript'


### PR DESCRIPTION
ext:styleguide provides the ability to create a frontend page tree
with proper site configuration. Because of included indexed_search
example, the indexed search TypoScript setup file is included into
the frontend site TypoScript configuration. However, the similar
include for the constants part has been missed, which is the reason
that the list/indexed_search example does not work out of the box,
if indexed_search extension is installed.

This change adds the corresponding constant import to the frontend
constant TypoScript setup to mitigate this issue and let the example
work out of the box, as long as ext:indexed_search is installed.

Releases: main, 11
Fixes: #321 for 11, prepared backport/cherry pick of PR #322

Note: Needs at least a tag / release so we can add it properly to v11 core dev