### PR TITLE
[BUGFIX] Switch to seleniarm/standalone-chromium for arm64 arch.

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -29,6 +29,7 @@ setUpDockerComposeDotEnv() {
         echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}"
         echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}"
         echo "DATABASE_DRIVER=${DATABASE_DRIVER}"
+        echo "DOCKER_SELENIUM_IMAGE=${DOCKER_SELENIUM_IMAGE}"
     } > .env
 }
 
@@ -171,6 +172,16 @@ EXTRA_TEST_OPTIONS=""
 SCRIPT_VERBOSE=0
 CGLCHECK_DRY_RUN=""
 DATABASE_DRIVER=""
+DOCKER_SELENIUM_IMAGE="selenium/standalone-chrome:3.141.59-20210713"
+
+# Detect arm64 and use a seleniarm image.
+# In a perfect world selenium would have a arm64 integrated, but that is not on the horizon.
+# So for the time being we have to use seleniarm image.
+ARCH=$(uname -m)
+if [ $ARCH = "arm64" ]; then
+    DOCKER_SELENIUM_IMAGE="seleniarm/standalone-chromium:4.1.2-20220227"
+    echo "Architecture" $ARCH "requires" $DOCKER_SELENIUM_IMAGE "to run acceptance tests."
+fi
 
 # Option parsing
 # Reset in case getopts has been used previously in the shell

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   chrome:
-    image: selenium/standalone-chrome:3.141.59-20210713
+    image: ${DOCKER_SELENIUM_IMAGE}
     tmpfs:
       - /dev/shm:rw,nosuid,nodev,noexec,relatime
 


### PR DESCRIPTION
Currently, selenium does not support arm64.
A condition was added to detect arm64 and use "seleniarm/standalone-chromium" image if running on arm64.