### PR TITLE
[BUGFIX] Allow custom forms

### DIFF
--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -2,8 +2,6 @@ TYPO3:
   CMS:
     Form:
       persistenceManager:
-        allowedFileMounts:
-          10: ~
         allowedExtensionPaths:
           10: 'EXT:styleguide/Resources/Private/Forms/'
         allowSaveToExtensionPaths: false


### PR DESCRIPTION
Even if styleguide is installed it must be possible to generate custom forms in fileadmin