### PR TITLE
[BUGFIX] Make a type annotation in a test more specific

### DIFF
--- a/Tests/Functional/TcaDataGenerator/GeneratorTest.php
+++ b/Tests/Functional/TcaDataGenerator/GeneratorTest.php
@@ -29,7 +29,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class GeneratorTest extends FunctionalTestCase
 {
     /**
-     * @var string[] Have styleguide loaded
+     * @var non-empty-string[] Have styleguide loaded
      */
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/styleguide',


### PR DESCRIPTION
This gets the type annotation in line with the latest testing
framework changes and fixes a PHPStan warning.

Releases: main, 11, 10