### PR TITLE
[TASK] Remove superfluous namespace within form configuration

### DIFF
--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -1,8 +1,5 @@
-TYPO3:
-  CMS:
-    Form:
-      persistenceManager:
-        allowedExtensionPaths:
-          10: 'EXT:styleguide/Resources/Private/Forms/'
-        allowSaveToExtensionPaths: false
-        allowDeleteFromExtensionPaths: false
+persistenceManager:
+  allowedExtensionPaths:
+    10: 'EXT:styleguide/Resources/Private/Forms/'
+  allowSaveToExtensionPaths: false
+  allowDeleteFromExtensionPaths: false


### PR DESCRIPTION
The namespace `TYPO3.CMS.Form` in form configuration was removed with TYPO3/typo3@451c896. With this patch, the appropriate form configuration has been adapted to follow the new recommendations.

Related: #97517
Releases: main