### PR TITLE
[TASK] Use phpstan github error format in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
 
       - name: phpstan
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "--error-format=github"
 
       - name: Unit Tests
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -68,7 +68,7 @@ Options:
             - 8.0: use PHP 8.0
             - 8.1: use PHP 8.1
 
-    -e "<phpunit or codeception options>"
+    -e "<phpunit, codeception or additional phpstan scan options>"
         Only with -s acceptance|functional|unit
         Additional options to send to phpunit (unit & functional tests) or codeception (acceptance
         tests). For phpunit, options starting with "--" must be added after options starting with "-".

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -336,7 +336,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon --no-progress --no-interaction
+        php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan.neon --no-progress --no-interaction ${EXTRA_TEST_OPTIONS}
       "
 
   phpstan_generate_baseline:


### PR DESCRIPTION
Use specific github error formatting for phpstan
error reporing in github actions. This adds the
phpstan errors directly into the file view on pull
requests for better readability. For direct pushes
on commit level it directly extracts and shows the
errors in the pane instead of only in the command
line view.

Releases: main, 11