### PR TITLE
[TASK] Drop default value for text field

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -406,7 +406,7 @@ CREATE TABLE tx_styleguide_inline_11 (
 );
 
 CREATE TABLE tx_styleguide_inline_11_child (
-    input_1 text DEFAULT '' NOT NULL
+    input_1 text
 );
 
 CREATE TABLE tx_styleguide_inline_1n_inline_1_child (


### PR DESCRIPTION
Text fields don't need a default value, and dropping this one
solves an issue with a changed DB field schema definition raised
in doctrine/dbal version 3.4.0.

It is the only text field with default value both in ext:styleguide
and in TYPO3 Core, so it is probably safe to remove the default value
and leave the handling of text fields inside database systems to
doctrine/dbal.