### PR TITLE
[BUGFIX] Drop removed field "alias"

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_group.php
+++ b/Configuration/TCA/tx_styleguide_elements_group.php
@@ -186,7 +186,7 @@ return [
                 'size' => 1,
                 'suggestOptions' => [
                     'default' => [
-                        'additionalSearchFields' => 'nav_title, alias, url',
+                        'additionalSearchFields' => 'nav_title, url',
                         'addWhere' => 'AND pages.doktype = 1',
                     ],
                 ],


### PR DESCRIPTION
The field `pages.alias` is removed for quite some but still used for the search in field `group_db_10`. The usage of said field is now removed.