### PR TITLE
[BUGFIX] Ensure testing works with CMSComposerInstallers 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Build/testing-docker/.env
 composer.lock
 Tests/Acceptance/Support/_generated/
 .sass-cache/
+/var

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "allow-plugins": {
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true
         }
     },
     "require-dev": {
@@ -45,6 +46,7 @@
         "codeception/module-cli": "^2.0",
         "codeception/module-webdriver": "^3.1",
         "phpstan/phpstan": "^1.4.8",
+        "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
         "typo3/cms-core": "~12.0@dev",
         "typo3/cms-frontend": "~12.0@dev",
         "typo3/cms-install": "~12.0@dev",


### PR DESCRIPTION
TYPY3v12 recently added hard requirement for `typo3/cms-composer-installers:5.x`, which install core system extensions and extensions in a different way. This breaks how typo3/testing-framework expects the existing structure to work for unit, functional and acceptance tests.

Until the final overwork for the testing-structure is implemented, the intermediate solution in form of a composer plugin is used, which basicly provides through symlinks the expected structure.

This *must* and will be vanish in the future or replaced by the official way.

Used command(s):

```shell
$ composer require --dev \
    sbuerk/typo3-cmscomposerinstallers-testingframework-bridge:^0.0.1
```