### PR TITLE
[TASK] Upgrade action/checkout to avoid deprecation message

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         php: [ '8.1' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate


### PR DESCRIPTION
GitHub has deprecated node v12 support for executing GitHub actions. This currently adds corresponding deprecation note to action results, also not failing for now.

This change updates action/checkout to use v3 instead of v2 to use Node v16 compatible version and thus avoiding the deprecation notice.

See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

![image](https://user-images.githubusercontent.com/1453466/195266967-87589921-586e-4ef5-a307-3ec101b207f8.png)
