### PR TITLE
[Backport] Complete creation of file references

### DIFF
--- a/Classes/TcaDataGenerator/GeneratorFrontend.php
+++ b/Classes/TcaDataGenerator/GeneratorFrontend.php
@@ -461,8 +461,10 @@ class GeneratorFrontend extends AbstractGenerator
                     $fieldname = 'image';
             }
 
+            $newIds = [];
             foreach ($files as $image) {
                 $newId = StringUtility::getUniqueId('NEW');
+                $newIds[] = $newId;
                 $recordData['sys_file_reference'][$newId] = [
                     'table_local' => 'sys_file',
                     'uid_local' => $image->getUid(),
@@ -470,6 +472,11 @@ class GeneratorFrontend extends AbstractGenerator
                     'tablenames' => 'tt_content',
                     'fieldname' => $fieldname,
                     'pid' => $content['pid'],
+                ];
+            }
+            if ($newIds !== []) {
+                $recordData['tt_content'][$content['uid']] = [
+                    $fieldname => implode(',', $newIds),
                 ];
             }
         }


### PR DESCRIPTION
With this the FAL field values are updated when file references are created

Provided backport of #365 - needs version tagging and raise on TYPO3 11.5 branch.

Resolves: #364
Releases: main, 11