### PR TITLE
[BUGFIX] styleguide uses core dev-main for --dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,9 @@
         "codeception/module-webdriver": "^3.1",
         "phpstan/phpstan": "^1.4.8",
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
-        "typo3/cms-core": "~12.0@dev",
-        "typo3/cms-frontend": "~12.0@dev",
-        "typo3/cms-install": "~12.0@dev",
+        "typo3/cms-core": "~12.2@dev",
+        "typo3/cms-frontend": "~12.2@dev",
+        "typo3/cms-install": "~12.2@dev",
         "typo3/coding-standards": "^0.5.0",
         "typo3/testing-framework": "dev-main"
     },


### PR DESCRIPTION
With v12.1 branching and releases, styleguide now
preferred 12.1 tags in it's testing dependencies.

Force ~12.2@dev to trigger dev-main core deps again.

composer req --dev typo3/cms-core:~12.2@dev \
	typo3/cms-frontend:~12.2@dev \
	typo3/cms-install:~12.2@dev