### PR TITLE
[TASK] Use typo3/testing-framework 8.x.x

### DIFF
--- a/Build/UnitTestsBootstrap.php
+++ b/Build/UnitTestsBootstrap.php
@@ -31,8 +31,9 @@ call_user_func(function () {
 
     $testbase->defineSitePath();
 
+    $composerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE === true;
     $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(0, $requestType);
+    \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
 
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
@@ -49,7 +50,7 @@ call_user_func(function () {
 
     $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
         'core',
-        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', []),
     );
     // Set all packages to active
     $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       typo3DatabaseHost: mariadb10
     volumes:
     - ${ROOT_DIR}:${ROOT_DIR}
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -81,8 +81,8 @@ services:
         done;
         echo Database is up;
         php -v | grep '^PHP';
-        mkdir -p Web/typo3temp/var/tests/
-        COMMAND=\"vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}\"
+        mkdir -p .Build/Web/typo3temp/var/tests/
+        COMMAND=\".Build/vendor/codeception/codeception/codecept run Backend -d -c Tests/codeception.yml ${TEST_FILE}\"
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
           $${COMMAND};
@@ -109,7 +109,7 @@ services:
       typo3DatabaseHost: mysql80
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -124,7 +124,7 @@ services:
         echo Database is up;
         php -v | grep '^PHP';
         mkdir -p Web/typo3temp/var/tests/
-        COMMAND=\"vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}\"
+        COMMAND=\".Build/vendor/codeception/codeception/codecept run Backend -d -c Tests/codeception.yml ${TEST_FILE}\"
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
           $${COMMAND};
@@ -151,7 +151,7 @@ services:
       typo3DatabasePassword: funcp
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -166,7 +166,7 @@ services:
         echo Database is up;
         php -v | grep '^PHP';
         mkdir -p Web/typo3temp/var/tests/
-        COMMAND=\"vendor/codeception/codeception/codecept run Backend -d -c Web/typo3conf/ext/styleguide/Tests/codeception.yml ${TEST_FILE}\"
+        COMMAND=\".Build/vendor/codeception/codeception/codecept run Backend -d -c Tests/codeception.yml ${TEST_FILE}\"
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
           $${COMMAND};
@@ -274,7 +274,7 @@ services:
       typo3DatabaseUsername: root
       typo3DatabasePassword: funcp
       typo3DatabaseHost: mariadb10
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -290,12 +290,12 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         fi
       "
 
@@ -312,7 +312,7 @@ services:
       typo3DatabaseUsername: root
       typo3DatabasePassword: funcp
       typo3DatabaseHost: mysql80
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -328,12 +328,12 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         fi
       "
 
@@ -350,7 +350,7 @@ services:
       typo3DatabaseUsername: ${HOST_USER}
       typo3DatabaseHost: postgres10
       typo3DatabasePassword: funcp
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -366,12 +366,12 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
         fi
       "
 
@@ -384,7 +384,7 @@ services:
       - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
     environment:
       typo3DatabaseDriver: pdo_sqlite
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -395,12 +395,12 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
         fi
       "
 
@@ -456,7 +456,7 @@ services:
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-    working_dir: ${ROOT_DIR}/.Build
+    working_dir: ${ROOT_DIR}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: >
@@ -467,11 +467,11 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
-          bin/phpunit -c Web/typo3conf/ext/styleguide/Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+          .Build/bin/phpunit -c Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
         fi
       "

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "allow-plugins": {
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true,
-            "composer/package-versions-deprecated": true,
-            "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true
+            "composer/package-versions-deprecated": true
         }
     },
     "require-dev": {
@@ -47,11 +46,10 @@
         "codeception/module-webdriver": "^4.0",
         "friendsofphp/php-cs-fixer": "^3.16.0",
         "phpstan/phpstan": "^1.10.14",
-        "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.3",
         "typo3/cms-core": "~12.4@dev",
         "typo3/cms-frontend": "~12.4@dev",
         "typo3/cms-install": "~12.4@dev",
-        "typo3/testing-framework": "dev-main"
+        "typo3/testing-framework": "^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
This change raises to testing-framework ^8.0.0. The now obsolete
"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge"
is removed again and necessary configuration changes applied.    

Used command(s):

```shell
composer remove --dev --no-update \
  "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge"

composer require --dev --no-update \
  "typo3/testing-framework":"^8.0"
```
