### PR TITLE
[TASK] Compatibility with associated array keys for TCA items

### DIFF
--- a/Classes/TcaDataGenerator/FieldGenerator/TypeRadio.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeRadio.php
@@ -52,7 +52,7 @@ class TypeRadio extends AbstractFieldGenerator implements FieldGeneratorInterfac
             $values = $data['fieldConfig']['config']['items'];
             array_shift($values);
             $value = array_shift($values);
-            $value = $value[1];
+            $value = $value[1] ?? $value['label'];
         }
         return (string)$value;
     }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelect.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelect.php
@@ -57,12 +57,15 @@ class TypeSelect extends AbstractFieldGenerator implements FieldGeneratorInterfa
                     continue;
                 }
                 // Ignore divider
-                if (isset($item[1]) && $item[1] !== '--div--') {
-                    if (count($result) <= $numberOfItemsToSelect) {
-                        $result[] = $item[1];
-                    }
-                    if (count($result) === $numberOfItemsToSelect) {
-                        break;
+                if ((isset($item[1]) || isset($item['value']))) {
+                    $value = $item[1] ?? $item['label'];
+                    if ($value !== '--div--') {
+                        if (count($result) <= $numberOfItemsToSelect) {
+                            $result[] = $value;
+                        }
+                        if (count($result) === $numberOfItemsToSelect) {
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a preparation patch for the upcoming switch to associated items array keys. The default value generators for select and radio are adjusted to work for both variants, so tests for the mentioned patch can go green.

Related patch: https://review.typo3.org/c/Packages/TYPO3.CMS/+/77626

Releases: main