### PR TITLE
[TASK] styleguide uses core dev-main for --dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,9 @@
         "codeception/module-webdriver": "^3.1",
         "phpstan/phpstan": "^1.4.8",
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
-        "typo3/cms-core": "~12.3@dev",
-        "typo3/cms-frontend": "~12.3@dev",
-        "typo3/cms-install": "~12.3@dev",
+        "typo3/cms-core": "~12.4@dev",
+        "typo3/cms-frontend": "~12.4@dev",
+        "typo3/cms-install": "~12.4@dev",
         "typo3/coding-standards": "^0.5.0",
         "typo3/testing-framework": "dev-main"
     },


### PR DESCRIPTION
Raise from 12.3@dev to 12.4@dev forces dev-main.