### PR TITLE
[TASK] Use friendsofphp/php-cs-fixer directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
       - name: CGL
-        if: ${{ matrix.php <= '8.1' }}
         run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
 
       - name: phpstan

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -1,0 +1,75 @@
+<?php
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+return (new \PhpCsFixer\Config())
+    ->setFinder(
+        (new PhpCsFixer\Finder())
+            ->ignoreVCSIgnored(true)
+            ->in([
+                __DIR__ . '/../../Build/',
+                __DIR__ . '/../../Classes/',
+                __DIR__ . '/../../Configuration/',
+                __DIR__ . '/../../Tests/',
+            ])
+    )
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        '@PER' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_after_opening_tag' => true,
+        'cast_spaces' => ['space' => 'none'],
+        'compact_nullable_typehint' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'function_typehint_space' => true,
+        'lowercase_cast' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_nullsafe_operator' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => true,
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        'single_trait_insert_per_statement' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ]);

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -214,8 +214,7 @@ services:
             .Build/bin/php-cs-fixer fix \
               -v \
               ${CGLCHECK_DRY_RUN} \
-              --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
-              --using-cache=no .
+              --config=Build/php-cs-fixer/config.php
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
@@ -224,8 +223,7 @@ services:
           .Build/bin/php-cs-fixer fix \
             -v \
             ${CGLCHECK_DRY_RUN} \
-            --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
-            --using-cache=no .
+            --config=Build/php-cs-fixer/config.php
         fi
       "
 

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  *
  * The TYPO3 project - inspiring people to share!
  */
+
 namespace TYPO3\CMS\Styleguide\Controller;
 
 use Psr\Http\Message\ResponseInterface;

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide;
 
 /*

--- a/Classes/Form/Element/User1Element.php
+++ b/Classes/Form/Element/User1Element.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Form\Element;
 
 /**

--- a/Classes/Service/KauderwelschService.php
+++ b/Classes/Service/KauderwelschService.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Service;
 
 /**

--- a/Classes/TcaDataGenerator/AbstractGenerator.php
+++ b/Classes/TcaDataGenerator/AbstractGenerator.php
@@ -219,7 +219,7 @@ abstract class AbstractGenerator
             }
 
             empty($data) ?: $dataHandler->process_datamap();
-            empty($commands) ?:$dataHandler->process_cmdmap();
+            empty($commands) ?: $dataHandler->process_cmdmap();
 
             // Update signal only if not running in cli mode
             if (!Environment::isCli()) {

--- a/Classes/TcaDataGenerator/Exception.php
+++ b/Classes/TcaDataGenerator/Exception.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/AbstractFieldGenerator.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/AbstractFieldGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/ConfigDefault.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/ConfigDefault.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeCheck.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeCheck.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeColor.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeColor.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetime.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeDbTypeDatetime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeDbTypeDatetime.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatDate.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatDate.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatDateDbTypeDate.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatDateDbTypeDate.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTime.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTimesec.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTimesec.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeRequiredFormatDate.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeRequiredFormatDate.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeEmail.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeEmail.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeFile.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeFile.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeFlex.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeFlex.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeFolder.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsers.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedBeUsersBeGroups.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedPages.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedStaticdata.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupAllowedSysFiles.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeGroupFal.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeImageManipulation.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeImageManipulation.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInline1n.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInline1n.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInlineExpandsingle.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInlineExpandsingle.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInlineFalSelectSingle12Foreign.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInlineFalSelectSingle12Foreign.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInlineUsecombination.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInlineUsecombination.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInput.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInput.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputDynamicTextWithRecordUid.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputDynamicTextWithRecordUid.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalAlphanum.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalAlphanum.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalIsIn.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalIsIn.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalMd5.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalMd5.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalNum.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalNum.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalUpper.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalUpper.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalYear.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputEvalYear.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputForceL10nParent.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputForceL10nParent.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputMax4.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputMax4.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputMax4Min4.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputMax4Min4.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInputWizardSelect.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInputWizardSelect.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeLink.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeLink.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeNone.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeNone.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeNoneFormatDateTime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeNoneFormatDateTime.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeNumber.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeNumber.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeNumberFormatDecimal.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeNumberFormatDecimal.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypePassthrough.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypePassthrough.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypePassword.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypePassword.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypePasswordHashedFalse.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypePasswordHashedFalse.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeRadio.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeRadio.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelect.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelect.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeMultipleForeignTableStaticData.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeMultipleForeignTableStaticData.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSelectTree.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSelectTree.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTable.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTable.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTableForType.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeSelectRenderTypeSingleForeignTableForType.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeText.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeText.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextDefaultExtrasRichtext.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextDefaultExtrasRichtext.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextFormatDatetime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextFormatDatetime.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextFormatT3editor.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextFormatT3editor.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextMax30.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextMax30.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardSelect.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardSelect.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardTable.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeTextWizardTable.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeUser.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeUser.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGeneratorInterface.php
+++ b/Classes/TcaDataGenerator/FieldGeneratorInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/FieldGeneratorResolver.php
+++ b/Classes/TcaDataGenerator/FieldGeneratorResolver.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/Generator.php
+++ b/Classes/TcaDataGenerator/Generator.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/GeneratorNotFoundException.php
+++ b/Classes/TcaDataGenerator/GeneratorNotFoundException.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/RecordData.php
+++ b/Classes/TcaDataGenerator/RecordData.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/RecordFinder.php
+++ b/Classes/TcaDataGenerator/RecordFinder.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/AbstractTableHandler.php
+++ b/Classes/TcaDataGenerator/TableHandler/AbstractTableHandler.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/General.php
+++ b/Classes/TcaDataGenerator/TableHandler/General.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/InlineMn.php
+++ b/Classes/TcaDataGenerator/TableHandler/InlineMn.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/InlineMnGroup.php
+++ b/Classes/TcaDataGenerator/TableHandler/InlineMnGroup.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/InlineMnSymmetric.php
+++ b/Classes/TcaDataGenerator/TableHandler/InlineMnSymmetric.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/InlineMnSymmetricGroup.php
+++ b/Classes/TcaDataGenerator/TableHandler/InlineMnSymmetricGroup.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandler/StaticData.php
+++ b/Classes/TcaDataGenerator/TableHandler/StaticData.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator\TableHandler;
 
 /*

--- a/Classes/TcaDataGenerator/TableHandlerInterface.php
+++ b/Classes/TcaDataGenerator/TableHandlerInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\TcaDataGenerator;
 
 /*

--- a/Tests/Acceptance/Backend/GenerateCommandCest.php
+++ b/Tests/Acceptance/Backend/GenerateCommandCest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Tests\Acceptance\Backend;
 
 /*

--- a/Tests/Acceptance/Backend/ModuleCest.php
+++ b/Tests/Acceptance/Backend/ModuleCest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Tests\Acceptance\Backend;
 
 /*

--- a/Tests/Acceptance/Support/BackendTester.php
+++ b/Tests/Acceptance/Support/BackendTester.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Tests\Acceptance\Support;
 
 /*

--- a/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace TYPO3\CMS\Styleguide\Tests\Acceptance\Support\Extension;
 
 /*

--- a/composer.json
+++ b/composer.json
@@ -45,12 +45,12 @@
         "codeception/module-asserts": "^3.0",
         "codeception/module-cli": "^2.0",
         "codeception/module-webdriver": "^4.0",
+        "friendsofphp/php-cs-fixer": "^3.16.0",
         "phpstan/phpstan": "^1.10.14",
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.3",
         "typo3/cms-core": "~12.4@dev",
         "typo3/cms-frontend": "~12.4@dev",
         "typo3/cms-install": "~12.4@dev",
-        "typo3/coding-standards": "^0.5.0",
         "typo3/testing-framework": "dev-main"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Use php-cs-fixer with own ruleset directly.
Use ruleset from current TYPO3 core.
Update codebase.
Activate cgl check with PHP 8.2 again.

> composer req --dev friendsofphp/php-cs-fixer:^3.16.0
> composer rem --dev typo3/coding-standards