### PR TITLE
[TASK] Remove lead class from introductory paragraphs and code example

### DIFF
--- a/Resources/Private/Templates/Backend/Avatar.html
+++ b/Resources/Private/Templates/Backend/Avatar.html
@@ -16,7 +16,7 @@
 
         <h1><f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:avatar" /></h1>
 
-        <p class="lead">Make the backend your backend and upload your personal profile picture.<br>
+        <p>Make the backend your backend and upload your personal profile picture.<br>
             Backend users can change their profile pictures within setup module.</p>
 
         <h2>Simple</h2>

--- a/Resources/Private/Templates/Backend/Filter.html
+++ b/Resources/Private/Templates/Backend/Filter.html
@@ -16,7 +16,7 @@
 
         <h1>Filter</h1>
 
-        <p class="lead">This is not a working example! It shows only the basic HTML structure to use.</p>
+        <p>This is not a working example! It shows only the basic HTML structure to use.</p>
 
         <sg:code language="html">
             <div class="row row-cols-auto align-items-end g-3">

--- a/Resources/Private/Templates/Backend/Icons.html
+++ b/Resources/Private/Templates/Backend/Icons.html
@@ -16,7 +16,7 @@
 
         <h1><f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:icons" /></h1>
 
-        <p class="lead">Icons can be used in backend modules. TYPO3 automatically sends the corresponding HTML output code.</p>
+        <p>Icons can be used in backend modules. TYPO3 automatically sends the corresponding HTML output code.</p>
 
         <div>
             <!-- Nav tabs -->

--- a/Resources/Private/Templates/Backend/Infobox.html
+++ b/Resources/Private/Templates/Backend/Infobox.html
@@ -14,7 +14,7 @@
 
         <h1><f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:infobox" /></h1>
 
-        <p class="lead">Is a fluid based widget for the backend that can be inserted as view helper.</p>
+        <p>Is a fluid based widget for the backend that can be inserted as view helper.</p>
 
         <h2>Optional icon</h2>
 

--- a/Resources/Private/Templates/Backend/Tca.html
+++ b/Resources/Private/Templates/Backend/Tca.html
@@ -15,7 +15,7 @@
 
         <h2>TCA test records</h2>
 
-        <p class="lead">
+        <p>
             This extension comes with a huge set of TCA records to show and test different combinations
             of TCA possibilities. This module can be used to create a page tree with default records and
             demo data.
@@ -35,7 +35,7 @@
 
         <h2>Create a frontend page tree including FE elements</h2>
 
-        <p class="lead">
+        <p>
             This creates a frontend with a page for each content element a site configuration and files
         </p>
 

--- a/Resources/Private/Templates/Backend/Typography.html
+++ b/Resources/Private/Templates/Backend/Typography.html
@@ -97,18 +97,6 @@
         </sg:code>
 
         <!--
-            Lead
-        -->
-
-        <h2>Lead copy</h2>
-
-        <p>The lead class can be added to paragraphs and other html content to highlight. Most used for the introduction text in backend modules.</p>
-
-        <sg:code language="html">
-            <p class="lead">Introduction text or lead copy text box with highlights.</p>
-        </sg:code>
-
-        <!--
             Emphasis
         -->
 


### PR DESCRIPTION
With v12 the p.lead was removed and should therefore no longer be used.