### PR TITLE
[BUGFIX] Be able to inject runtime cache into SiteFinder

### DIFF
--- a/Classes/TcaDataGenerator/AbstractGenerator.php
+++ b/Classes/TcaDataGenerator/AbstractGenerator.php
@@ -42,7 +42,15 @@ abstract class AbstractGenerator
     {
         $recordFinder = GeneralUtility::makeInstance(RecordFinder::class);
         // When the DataHandler created the page tree, a default site configuration has been added. Fetch,  rename, update.
-        $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByRootPageId($topPageUid);
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+
+        /**
+         * In acceptance tests $siteFinder->getSiteByRootPageId() fails when runtime cache
+         * gets injected into SiteFinder, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/78311/19..21
+         */
+        $siteFinder->getAllSites(false);
+
+        $site = $siteFinder->getSiteByRootPageId($topPageUid);
         $siteConfiguration = GeneralUtility::makeInstance(SiteConfiguration::class);
         $siteIdentifier = 'styleguide-demo-' . $topPageUid;
         $siteConfiguration->rename($site->getIdentifier(), $siteIdentifier);


### PR DESCRIPTION
This is about the Exception in https://git.typo3.org/typo3/CI/cms/-/jobs/2335240

```php
In SiteFinder.php line 87:
                                                                 
  [TYPO3\CMS\Core\Exception\SiteNotFoundException (1521668882)]  
  No site found for root page id 51                              
                                                                 
Exception trace:
  at /builds/typo3/CI/cms/typo3/sysext/core/Classes/Site/SiteFinder.php:87
 TYPO3\CMS\Core\Site\SiteFinder->getSiteByRootPageId() at /builds/typo3/CI/cms/vendor/typo3/cms-styleguide/Classes/TcaDataGenerator/AbstractGenerator.php:45
 TYPO3\CMS\Styleguide\TcaDataGenerator\AbstractGenerator->createSiteConfiguration() at /builds/typo3/CI/cms/vendor/typo3/cms-styleguide/Classes/TcaDataGenerator/Generator.php:127
```

In https://review.typo3.org/c/Packages/TYPO3.CMS/+/78311/19..21 I inject the runtime cache into SiteFinder and this makes acceptance tests fail.

This change helps, but it looks little odd to me and rather as a workaround. SiteFinder uses SiteConfiguration (a singleton), whose caches get resetted in 
`\TYPO3\CMS\Core\Configuration\SiteConfiguration::write()` when a new site is added.