### PR TITLE
[TASK] Set correct core version in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,10 +7,10 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'TYPO3 Core Team',
     'author_email' => 'typo3cms@typo3.org',
     'state' => 'stable',
-    'version' => '12.0.0',
+    'version' => '13.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.0.0-12.99.99',
+            'typo3' => '13.0.0-13.99.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
This change sets the version in the `ext_emconf.php`
to the next version, matching the current TYPO3 core
main branch version.
