### PR TITLE
[BUGFIX] Generate correct values for `datetime` type fields

### DIFF
--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTime.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTime.php
@@ -17,6 +17,7 @@ namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Database\Query\QueryHelper;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGeneratorInterface;
 
 /**
@@ -47,6 +48,16 @@ class TypeDatetimeFormatTime extends AbstractFieldGenerator implements FieldGene
     public function generate(array $data): string
     {
         // 05:23
-        return '19380';
+        $value = '19380';
+
+        // We need to partly do the same work as the DataHandler for some dbTypes for the DateTime type to get
+        // database compatible values. Without it, we will get invalid format database exception when inserted.
+        // See \TYPO3\CMS\Core\DataHandling\DataHandler::checkValueForDatetime().
+        $nativeDateTimeType = $data['fieldConfig']['config']['dbType'] ?? '';
+        $dateTimeFormats = QueryHelper::getDateTimeFormats();
+        $nativeDateTimeFieldFormat = $dateTimeFormats[$nativeDateTimeType]['format'] ?? 'h:i:s';
+        $value =  gmdate($nativeDateTimeFieldFormat, (int)$value);
+
+        return $value;
     }
 }

--- a/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTimesec.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeDatetimeFormatTimesec.php
@@ -17,6 +17,7 @@ namespace TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGenerator;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Database\Query\QueryHelper;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\FieldGeneratorInterface;
 
 /**
@@ -47,6 +48,16 @@ class TypeDatetimeFormatTimesec extends AbstractFieldGenerator implements FieldG
     public function generate(array $data): string
     {
         // 05:23:42
-        return '19422';
+        $value = '19422';
+
+        // We need to partly do the same work as the DataHandler for some dbTypes for the DateTime type to get
+        // database compatible values. Without it, we will get invalid format database exception when inserted.
+        // See \TYPO3\CMS\Core\DataHandling\DataHandler::checkValueForDatetime().
+        $nativeDateTimeType = $data['fieldConfig']['config']['dbType'] ?? '';
+        $dateTimeFormats = QueryHelper::getDateTimeFormats();
+        $nativeDateTimeFieldFormat = $dateTimeFormats[$nativeDateTimeType]['format'] ?? 'h:i:s';
+        $value =  gmdate($nativeDateTimeFieldFormat, (int)$value);
+
+        return $value;
     }
 }


### PR DESCRIPTION
The database generator does not use the DataHandler for
all operation due to some performance considerations.

That means, that special handlings included in DataHandler
needs to be adopted - at least in a stripped down version.

For example, the DataHandler contains value transformation
for `type = datetime` when the `dbType` is one of following
types: `datetime`, `time`, `timesec`.

Until now, now records are created with this constellation.
To be able to add such fields in the future, we need to mimic
partly work done by the DataHandler for these type in record
generation.

Releases: main, 12
