### PR TITLE
[TASK] Replace obsolete Font Awesome icons (main)

### DIFF
--- a/Resources/Private/Templates/Backend/Icons.html
+++ b/Resources/Private/Templates/Backend/Icons.html
@@ -103,7 +103,7 @@
                             </div>
                             <div class="form-group col-md-12">
                                 <div class="input-group">
-                                    <div class="input-group-addon"><i class="fa fa-search"></i></div>
+                                    <div class="input-group-addon"><core:icon identifier="actions-search" size="default" /></div>
                                     <input type="text" class="form-control input-lg" id="search-field" placeholder="Icon identifier">
                                 </div>
                             </div>
@@ -123,8 +123,8 @@
                         <f:for each="{deprecatedIcons}" key="icon" as="alternativeIcon">
                             <div class="col-md-2 icon-container icon-deprecated-container" data-icon-identifier="{icon}">
                                 <span class="icon-container-icon"><core:icon identifier="{icon}" size="large" /></span>
-                                <span class="icon-container-label"><i class="fa fa-arrow-circle-left"></i> {icon}</span>
-                                <span class="icon-container-label"><i class="fa fa-arrow-circle-right"></i> {alternativeIcon}</span>
+                                <span class="icon-container-label">{icon}</span>
+                                <span class="icon-container-label"><core:icon identifier="actions-arrow-down-right-alt" size="small" /> {alternativeIcon}</span>
                             </div>
                         </f:for>
                     </div>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -43,12 +43,12 @@
                 </div>
                 <div class="card-footer">
                     <button data-href="{f:be.uri(route: 'help_styleguide', parameters: '{action: \'tcaCreate\'}')}" class="btn btn-default{f:if(condition: '{demoExists} = true', then: ' disabled')} t3js-generator-action" id="t3-tca-pagetree-create">
-                        <i class="fa fa-plus fa-fw"></i>
+                        <core:icon identifier="actions-plus" size="small" />
                         <f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:tcaCreateButton" />
                     </button>
 
                     <button data-href="{f:be.uri(route: 'help_styleguide', parameters: '{action: \'tcaDelete\'}')}" class="btn btn-danger{f:if(condition: '{demoExists} != true', then: ' disabled')}  t3js-generator-action" id="t3-tca-pagetree-delete">
-                        <i class="fa fa-trash fa-fw"></i>
+                        <core:icon identifier="actions-delete" size="small" />
                         <f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:tcaDeleteButton" />
                     </button>
                 </div>
@@ -68,12 +68,12 @@
                 </div>
                 <div class="card-footer">
                     <button data-href="{f:be.uri(route:'help_styleguide', parameters: '{action: \'frontendCreate\'}')}" class="btn btn-default{f:if(condition: '{demoFrontendExists} = true', then: ' disabled')}  t3js-generator-action" id="t3-ce-pagetree-create">
-                        <i class="fa fa-plus fa-fw"></i>
+                        <core:icon identifier="actions-plus" size="small" />
                         <f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:frontendCreateButton" />
                     </button>
 
                     <button data-href="{f:be.uri(route:'help_styleguide', parameters: '{action: \'frontendDelete\'}')}" class="btn btn-danger{f:if(condition: '{demoFrontendExists} != true', then: ' disabled')}  t3js-generator-action" id="t3-ce-pagetree-delete">
-                        <i class="fa fa-trash fa-fw"></i>
+                        <core:icon identifier="actions-delete" size="small" />
                         <f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:frontendDeleteButton" />
                     </button>
                 </div>

--- a/Resources/Public/JavaScript/processing-indicator.js
+++ b/Resources/Public/JavaScript/processing-indicator.js
@@ -20,15 +20,15 @@ import Notification from '@typo3/backend/notification.js';
 
 let itemProcessing = 0;
 
-Icons.getIcon('spinner-circle-dark', Icons.sizes.small).then(function(spinner) {
+Icons.getIcon('spinner-circle', Icons.sizes.small).then(function(spinner) {
   document.querySelectorAll('.t3js-generator-action').forEach((button) => {
     let url = button.dataset.href;
     button.addEventListener('click', (e) => {
       e.preventDefault();
-      let originalIcon = button.querySelector('i').outerHTML;
+      let originalIcon = button.querySelector('span').outerHTML;
       let disabledButton = button.parentNode.querySelector('button.disabled');
 
-      e.target.querySelector('i').outerHTML = spinner;
+      e.target.querySelector('span').outerHTML = spinner;
       NProgress.start();
       itemProcessing++
       e.target.classList.add('disabled');

--- a/Tests/Acceptance/Backend/ModuleCest.php
+++ b/Tests/Acceptance/Backend/ModuleCest.php
@@ -102,10 +102,10 @@ class ModuleCest
 
     private function seeResponse(BackendTester $I, string $message): void
     {
-        $I->seeElement('.t3js-generator-action .icon-spinner-circle-dark');
+        $I->seeElement('.t3js-generator-action .icon-spinner-circle');
         $I->switchToMainFrame();
         $I->waitForText($message, 60, '.alert-message');
         $I->switchToContentFrame();
-        $I->dontSeeElement('.t3js-generator-action .icon-spinner-circle-dark');
+        $I->dontSeeElement('.t3js-generator-action .icon-spinner-circle');
     }
 }


### PR DESCRIPTION
This change replaces the obsolete "Font Awesome Icons"
markup on the icon search page and in the section to
create example page trees with TCA demo records and
content elements.

JavaScript selectors are adjusted to match the changed
markup.

The spinner is changed from dark as a side-change for
a cleaner user experiance and aligns to a recently core
patch [1].

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/80103

Resolves: #416
Releases: main, 12
