### PR TITLE
[TASK] Add a page for card component with instructions and examples

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -53,6 +53,7 @@ class BackendController
         'trees',
         'tab',
         'tables',
+        'cards',
         'avatar',
         'buttons',
         'infobox',
@@ -215,6 +216,19 @@ class BackendController
             'currentAction' => 'tables',
         ]);
         return $moduleTemplate->renderResponse('Backend/Tables');
+    }
+
+    private function cardsAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->pageRenderer->addJsFile('EXT:styleguide/Resources/Public/JavaScript/prism.js');
+        $this->pageRenderer->addCssFile('EXT:styleguide/Resources/Public/Css/backend.css');
+        $moduleTemplate = $this->moduleTemplateFactory->create($request);
+        $this->addShortcutButton($moduleTemplate, 'cards');
+        $moduleTemplate->assignMultiple([
+            'actions' => $this->allowedActions,
+            'currentAction' => 'cards',
+        ]);
+        return $moduleTemplate->renderResponse('Backend/Cards');
     }
 
     private function frontendCreateAction(): ResponseInterface

--- a/Classes/ViewHelpers/CodeViewHelper.php
+++ b/Classes/ViewHelpers/CodeViewHelper.php
@@ -38,6 +38,7 @@ class CodeViewHelper extends AbstractViewHelper
     {
         $this->registerArgument('language', 'string', 'the language identifier, e.g. html, php, etc.', true);
         $this->registerArgument('codeonly', 'bool', 'if true show only the code but not the example', false, false);
+        $this->registerArgument('exampleonly', 'bool', 'if true show only the example but not the code', false, false);
     }
 
     public function render(): string
@@ -65,13 +66,15 @@ class CodeViewHelper extends AbstractViewHelper
             $markup[] = $content;
             $markup[] = '</div>';
         }
-        $markup[] = '<div class="example code">';
-        $markup[] = '<pre>';
-        $markup[] = '<code class="language-' . htmlspecialchars($this->arguments['language']) . '">';
-        $markup[] = htmlspecialchars($content);
-        $markup[] = '</code>';
-        $markup[] = '</pre>';
-        $markup[] = '</div>';
+        if (!$this->arguments['exampleonly']) {
+            $markup[] = '<div class="example code">';
+            $markup[] = '<pre>';
+            $markup[] = '<code class="language-' . htmlspecialchars($this->arguments['language']) . '">';
+            $markup[] = htmlspecialchars($content);
+            $markup[] = '</code>';
+            $markup[] = '</pre>';
+            $markup[] = '</div>';
+        }
         return implode('', $markup);
     }
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -36,6 +36,9 @@
 			<trans-unit id="typography" xml:space="preserve">
 				<source>Typography</source>
 			</trans-unit>
+			<trans-unit id="cards" xml:space="preserve">
+				<source>Cards</source>
+			</trans-unit>
 			<trans-unit id="colors" xml:space="preserve">
 				<source>Colors</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Backend/Cards.html
+++ b/Resources/Private/Templates/Backend/Cards.html
@@ -1,0 +1,733 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:sg="http://typo3.org/ns/TYPO3/CMS/Styleguide/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+
+    <div id="container-navigation">
+        <f:render partial="Backend/Navigation" arguments="{currentAction: currentAction, actions: actions}" />
+    </div>
+    <div id="container-content">
+        <h1><f:translate key="LLL:EXT:styleguide/Resources/Private/Language/locallang.xlf:cards" /></h1>
+
+        <p>Cards can be displayed individually or in groups.</p>
+
+        <h2>Single card</h2>
+
+        <p>
+            This is an example of a single card with its possible content. Unless further defined via CSS, a single card
+            takes on the full width of the place it has been put into.
+        </p>
+
+        <sg:code language="html">
+            <div class="card">
+                <div class="card-header">
+                    <div class="card-icon">
+                        <core:icon identifier="module-styleguide" size="medium" />
+                    </div>
+                    <div class="card-header-body">
+                        <h2 class="card-title">Headline</h2>
+                        <span class="card-subtitle">Subtitle</span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p class="card-text">
+                        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
+                        ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                    </p>
+                </div>
+                <div class="card-footer">
+                    <a href="#" class="btn btn-default">Link title</a>
+                </div>
+            </div>
+        </sg:code>
+
+        <h2>Multiple cards</h2>
+
+        <p>
+            To display multiple cards, group them by wrapping them with <code>div.card-container</code>.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Item 1</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                                invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Item 2</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat,
+                                vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio
+                                dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla
+                                facilisi.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Item 3 - with a longer text that requires multiple lines</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis
+                                nisl ut aliquip ex ea commodo consequat.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <sg:code language="html" codeonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h2>Card sizes</h2>
+
+        <p>
+            To give the card the desired size, assign one of the following classes to the <code>div.card</code>. If only
+            a single card is used, it must be wrapped with <code>div.card-container</code> as with multiple cards.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Small size (<code>.card-size-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                The card has a width of 25% of the card container.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Small size (<code>.card-size-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                The card has a width of 25% of the card container.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card-container">
+                <div class="card card-size-medium">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Medium size (<code>.card-size-medium</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                The card has a width of 50% of the card container.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-medium">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Medium size (<code>.card-size-medium</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                                invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card-container">
+                <div class="card card-size-large">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Large size (<code>.card-size-large</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                The card has a width of 100% of the card container.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h3>Special size</h3>
+        <p>
+            Many submodules of the module "Admin Tools" use cards on their main page. They use a special form of small
+            size that ensures that the card retains its size in all viewports.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Fixed small size (<code>.card-size-fixed-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                The card keeps a fixed small size in all viewports.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Fixed small size (<code>.card-size-fixed-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                                invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Fixed small size (<code>.card-size-fixed-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                At vero eos et accusam et justo duo dolores et ea rebum.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Fixed small size (<code>.card-size-fixed-small</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis
+                                nisl ut aliquip ex ea commodo consequat.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h2>Alignment</h2>
+
+        <p>
+            If you have multiple cards and each have a link or button, they may not align properly depending on the
+            length of the previously placed headings or description text. To ensure they align regardless of previous
+            content, place the link or button in the <code>div.card-footer</code> - this way the links will always be
+            placed at the bottom of the card.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Headline</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                                invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="card-footer">
+                        <a href="#" class="btn btn-default">Link title</a>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Headline</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                At vero eos et accusam et justo duo dolores et ea rebum.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn btn-default">
+                            <core:icon identifier="actions-plus" size="small" /> Button title
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <sg:code language="html" codeonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                    <div class="card-footer">
+                        <a href="#" class="btn btn-default">Link title</a>
+                    </div>
+                </div>
+                <div class="card card-size-fixed-small">
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                    <div class="card-footer">
+                        <button class="btn btn-default">
+                            <core:icon identifier="actions-plus" size="small" /> Button title
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h2>Coloured cards</h2>
+
+        <p>
+            It is possible to colour cards. However, this option is rarely used - so please use this option sparingly.
+            All available options are listed below. If needed assign one of the following classes to the
+            <code>div.card</code>.<br>
+            If you want to display the card in its default state, it is not necessary to add <code>.card-default</code>
+            to the <code>div.card</code> - just omit the extra class.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-small card-primary">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Primary (<code>.card-primary</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-secondary">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Secondary (<code>.card-secondary</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-success">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Success (<code>.card-success</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-info">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Info (<code>.card-info</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-warning">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Warning (<code>.card-warning</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-danger">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Danger (<code>.card-danger</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-notice">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Notice (<code>.card-notice</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-dark">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Dark (<code>.card-dark</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-light">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Light (<code>.card-light</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card card-size-small card-default">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h3 class="card-title">Default (<code>.card-default</code>)</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-text">
+                            <p>
+                                Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <f:be.infobox title="Note" state="-1">
+            Not all listed classes currently have a visual effect. Since they are defined in the CSS, we keep them here
+            in the listing in case they come into use later.
+        </f:be.infobox>
+
+        <h2>Further usages</h2>
+
+        <p>
+            Some modules and views extend the card component with additional elements. Some known uses are listed below.
+        </p>
+
+        <h3>"About" module</h3>
+
+        <p>
+            The listing of submodules in the "About" module uses an additional <code>div.card-longdesc</code> in
+            <code>div.card-header</code>.
+        </p>
+
+        <sg:code language="html">
+            <section class="card-container">
+                <div class="card card-size-medium">
+                    <div class="card-header">
+                        <div class="card-icon">
+                            <core:icon identifier="module-styleguide" size="medium" />
+                        </div>
+                        <div class="card-header-body">
+                            <h2 class="card-title">Submodule title</h2>
+                            <span class="card-subtitle">Short description</span>
+                            <div class="card-longdesc">Description of the submodule</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </sg:code>
+
+        <p>
+            In some sections of the "About" module, tables are included within the card component.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="container-small about-module">
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="card-title">Title</h3>
+                        <p>
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+                        </p>
+                    </div>
+                    <div class="table-fit">
+                        <table class="table">
+                            <thead>
+                            <tr>
+                                <th width="50%">Table header cell</th>
+                                <th>Table header cell</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td>
+                                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+                                    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                                </td>
+                                <td>
+                                    Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat,
+                                    vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio
+                                    dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla
+                                    facilisi.
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <sg:code language="html" codeonly="true">
+            <div class="card">
+                <div class="card-body">...</div>
+                <div class="table-fit">
+                    <table class="table">
+                        <thead>...</thead>
+                        <tbody>...</tbody>
+                    </table>
+                </div>
+            </div>
+        </sg:code>
+
+        <h3>Element information</h3>
+
+        <p>
+            On top of the element information overlay, rows are included within the card component.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-medium">
+                    <div class="card-header">
+                        <div class="card-icon">
+                            <core:icon identifier="module-styleguide" size="small" />
+                        </div>
+                        <div class="card-header-body">
+                            <h3 class="card-title">Menu sitemap pages<code>[70]</code></h3>
+                            <span class="card-subtitle">Page Content</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <strong>Created At</strong><br>
+                                01-01-70 00:00
+                            </div>
+                            <div class="col-md-6">
+                                <strong>Last Modified</strong><br>
+                                01-01-70 00:00
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <sg:code language="html" codeonly="true">
+            <div class="card-container">
+                <div class="card card-size-medium">
+                    <div class="card-header">...</div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <strong>Created At</strong><br>
+                                01-01-70 00:00
+                            </div>
+                            <div class="col-md-6">
+                                <strong>Last Modified</strong><br>
+                                01-01-70 00:00
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h3>"Extension Manager" module</h3>
+
+        <p>
+            In the extension manager it is possible to get pre-configured distributions. For this view, the cards have
+            been enhanced with an image and some badges.
+        </p>
+
+        <sg:code language="html" exampleonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-image">
+                        <a href="#" class="distribution-image">
+                            <f:image src="EXT:extensionmanager/Resources/Public/Images/Distribution.svg" />
+                        </a>
+                        <div class="card-image-badge">
+                            <span class="badge badge-success">0.0.0 - 99.9.99</span>
+                        </div>
+                        <div class="distribution-official-badge">
+                            <f:image
+                                src="EXT:extensionmanager/Resources/Public/Images/OfficialBadge.svg"
+                                height="64"
+                                width="64"
+                            />
+                        </div>
+                    </div>
+                    <div class="card-header">
+                        <h3 class="card-title">
+                            <a href="#">Title of the pre-configured distribution</a>
+                        </h3>
+                        <span class="card-subtitle">Category</span>
+                    </div>
+                    <div class="card-body">
+                        <p class="card-text">
+                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
+                            ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                        </p>
+                    </div>
+                    <div class="card-footer">
+                        <a href="#" class="btn btn-default">
+                            <core:icon identifier="actions-system-extension-import" /> Install
+                        </a>
+                        <a href="#" class="btn btn-link">Show Details</a>
+                    </div>
+                </div>
+            </div>
+        </sg:code>
+
+        <sg:code language="html" codeonly="true">
+            <div class="card-container">
+                <div class="card card-size-fixed-small">
+                    <div class="card-image">
+                        <a href="#" class="distribution-image">
+                            <f:image src="EXT:extensionmanager/Resources/Public/Images/Distribution.svg" />
+                        </a>
+                        <div class="card-image-badge">
+                            <span class="badge badge-success">0.0.0 - 99.9.99</span>
+                        </div>
+                        <div class="distribution-official-badge">
+                            <f:image
+                                src="EXT:extensionmanager/Resources/Public/Images/OfficialBadge.svg"
+                                height="64"
+                                width="64"
+                            />
+                        </div>
+                    </div>
+                    <div class="card-header">...</div>
+                    <div class="card-body">...</div>
+                    <div class="card-footer">...</div>
+                </div>
+            </div>
+        </sg:code>
+
+        <h3>Others</h3>
+
+        <p>
+            It is also possible to display forms and form fields in cards. This is done, for example, in the "Upload
+            Extension" section of the Extension Manager and in the "Feature Toggles" overlay in the "Settings" module.
+        </p>
+    </div>
+
+</f:section>
+
+</html>


### PR DESCRIPTION
TYPO3 uses cards in the install tool as a valid backend component.

This change adds them to the styleguide as example for extension
developers and how to use them.

Resolves: #359
Releases: main, 12