### PR TITLE
[TASK] Avoid TCA MM_hasUidField

### DIFF
--- a/Configuration/TCA/tx_styleguide_inline_mm.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm.php
@@ -86,7 +86,6 @@ return [
                 'type' => 'inline',
                 'foreign_table' => 'tx_styleguide_inline_mm_child',
                 'MM' => 'tx_styleguide_inline_mm_child_rel',
-                'MM_hasUidField' => true,
                 'appearance' => [
                     'showSynchronizationLink' => 1,
                     'showAllLocalizationLink' => 1,

--- a/Configuration/TCA/tx_styleguide_inline_mm_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_child.php
@@ -87,7 +87,6 @@ return [
                 'type' => 'inline',
                 'foreign_table' => 'tx_styleguide_inline_mm',
                 'MM' => 'tx_styleguide_inline_mm_child_rel',
-                'MM_hasUidField' => true,
                 'MM_opposite_field' => 'inline_1',
                 'maxitems' => 10,
                 'appearance' => [
@@ -103,7 +102,6 @@ return [
                 'type' => 'inline',
                 'foreign_table' => 'tx_styleguide_inline_mm_childchild',
                 'MM' => 'tx_styleguide_inline_mm_child_childchild_rel',
-                'MM_hasUidField' => true,
                 'appearance' => [
                     'showSynchronizationLink' => 1,
                     'showAllLocalizationLink' => 1,

--- a/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
+++ b/Configuration/TCA/tx_styleguide_inline_mm_childchild.php
@@ -87,7 +87,6 @@ return [
                 'type' => 'inline',
                 'foreign_table' => 'tx_styleguide_inline_mm_child',
                 'MM' => 'tx_styleguide_inline_mm_child_childchild_rel',
-                'MM_hasUidField' => true,
                 'MM_opposite_field' => 'inline_2',
                 'maxitems' => 10,
                 'appearance' => [


### PR DESCRIPTION
This config is not needed for those tables and
will become obsolete with TYPO3 v13.

Releases: main