### PR TITLE
[TASK] Remove all type=email sql field definitions

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -864,6 +864,21 @@ return [
                 'readOnly' => true,
             ],
         ],
+        'email_3' => [
+            'label' => 'email_3 nullable',
+            'config' => [
+                'type' => 'email',
+                'nullable' => true,
+            ],
+        ],
+        'email_4' => [
+            'label' => 'email_4 nullable with placeholder',
+            'config' => [
+                'type' => 'email',
+                'nullable' => true,
+                'placeholder' => 'info@example.org',
+            ],
+        ],
 
         'text_1' => [
             'l10n_mode' => 'prefixLangTitle description',
@@ -1859,7 +1874,7 @@ backend_layout {
                 --div--;number,
                     number_1, number_2, number_3, number_4, number_5, number_6, number_7,
                 --div--;email,
-                    email_1, email_2,
+                    email_1, email_2, email_3, email_4,
                 --div--;text,
                     text_1, text_2, text_3, text_4, text_5, text_6, text_7, text_9, text_10,
                     text_11, text_12, text_13, text_18, text_14, text_15, text_16, text_17, text_19,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -126,9 +126,6 @@ CREATE TABLE tx_styleguide_elements_basic (
     number_6 int(11) DEFAULT '0' NOT NULL,
     number_7 int(11) DEFAULT '0' NOT NULL,
 
-    email_1 text,
-    email_2 text,
-
     text_1 text,
     text_2 text,
     text_3 text,


### PR DESCRIPTION
We're adding core code to add default sql definitions derived from TCA. Fields of type=email do not need to be set anymore.

Releases: main
Related: https://forge.typo3.org/issues/101654