### PR TITLE
[TASK] Stabilize acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ![tests](https://github.com/TYPO3/styleguide/workflows/tests/badge.svg)
+![tests-ac-mariadb-mysqli](https://github.com/TYPO3/styleguide/actions/workflows/tests-ac-mariadb-mysqli.yml/badge.svg)
+![tests-ac-mariadb-pdo-mysql](https://github.com/TYPO3/styleguide/actions/workflows/tests-ac-mariadb-pdo-mysql.yml/badge.svg)
+![tests-ac-mysql-mysqli](https://github.com/TYPO3/styleguide/actions/workflows/tests-ac-mysql-mysqli.yml/badge.svg)
+![tests-ac-mysql-pdo-mysql](https://github.com/TYPO3/styleguide/actions/workflows/tests-ac-mysql-pdo-mysql.yml/badge.svg)
+![tests-ac-postgres](https://github.com/TYPO3/styleguide/actions/workflows/tests-ac-postgres.yml/badge.svg)
 
 TYPO3 CMS Backend Styleguide
 ============================

--- a/Tests/Acceptance/Backend/ModuleCest.php
+++ b/Tests/Acceptance/Backend/ModuleCest.php
@@ -37,7 +37,7 @@ class ModuleCest
      */
     public function _before(BackendTester $I)
     {
-        $I->useExistingSession('admin');
+        $I->useExistingSession('admin', 1);
         $I->click(Topbar::$dropdownToggleSelector, self::$topBarModuleSelector);
         $I->canSee('Styleguide', self::$topBarModuleSelector);
         $I->click('Styleguide', self::$topBarModuleSelector);


### PR DESCRIPTION
Some acceptance tests tends to produce errors
in the JavaScript console. This can be mitigated
by using a higher waitTime for `useExistingSession`.

Additionally, missing badges are added to the
README.md file.

Releases: main
