### PR TITLE
[BUGFIX] Remove wrong labels for render type `checkboxToggle`

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -1312,8 +1312,6 @@ backend_layout {
                 'items' => [
                     [
                         'label' => 'foo',
-                        'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled',
                     ],
                 ],
             ],
@@ -1327,8 +1325,6 @@ backend_layout {
                 'items' => [
                     [
                         'label' => 'foo',
-                        'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled',
                         'invertStateDisplay' => true,
                     ],
                 ],
@@ -1416,8 +1412,6 @@ backend_layout {
                 'items' => [
                     [
                         'label' => 'foo',
-                        'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled',
                     ],
                 ],
             ],

--- a/Configuration/TCA/tx_styleguide_l10nreadonly.php
+++ b/Configuration/TCA/tx_styleguide_l10nreadonly.php
@@ -152,8 +152,6 @@ return [
                 'items' => [
                     [
                         'label' => 'foo',
-                        'labelChecked' => 'Enabled',
-                        'labelUnchecked' => 'Disabled',
                         'invertStateDisplay' => true,
                     ],
                     [


### PR DESCRIPTION
The render type `checkboxToggle` has no labels for checked or unchecked states. These are only available for `checkboxLabeledToggle`.

See also TYPO3-Documentation/TYPO3CMS-Reference-TCA#767