### PR TITLE
[TASK] Add example for TCA type='language'

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_basic.php
+++ b/Configuration/TCA/tx_styleguide_elements_basic.php
@@ -1848,6 +1848,13 @@ backend_layout {
             ],
         ],
 
+        'language_1' => [
+            'label' => 'language_1',
+            'description' => 'simple language selection',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
     ],
 
     'types' => [
@@ -1895,6 +1902,8 @@ backend_layout {
                     unknown_1,
                 --div--;in flex,
                     flex_1,
+                --div--;language,
+                    language_1,
                 --div--;meta,
                     disable, sys_language_uid, l10n_parent, l10n_source,
             ',


### PR DESCRIPTION
The TCA type is currently only used as sys_language_uid system field, but can also be used in user land as a business field. To provide a set of possibilities for the type, a simple implementation is added.