### PR TITLE
[TASK] Remove all type=text sql field definitions

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -25,7 +25,6 @@ CREATE TABLE fe_users (
 
 CREATE TABLE tx_styleguide_ctrl_common (
     title text,
-    description text,
 );
 
 
@@ -120,25 +119,7 @@ CREATE TABLE tx_styleguide_elements_basic (
     number_6 int(11) DEFAULT '0' NOT NULL,
     number_7 int(11) DEFAULT '0' NOT NULL,
 
-    text_1 text,
-    text_2 text,
-    text_3 text,
-    text_4 text,
-    text_5 text,
-    text_6 text,
-    text_7 text,
-    text_9 text,
-    text_10 text,
-    text_11 text,
     text_12 text,
-    text_13 text,
-    text_14 text,
-    text_15 text,
-    text_16 text,
-    text_17 text,
-    text_18 text,
-    text_19 text,
-    text_20 text,
 
     radio_1 int(11) DEFAULT '0' NOT NULL,
     radio_2 int(11) DEFAULT '0' NOT NULL,
@@ -171,11 +152,6 @@ CREATE TABLE tx_styleguide_elements_imagemanipulation (
 
 
 CREATE TABLE tx_styleguide_elements_rte (
-    rte_1 text,
-    rte_2 text,
-    rte_3 text,
-    rte_4 text,
-    rte_5 text,
     rte_inline_1 text,
     input_palette_1 text,
     rte_palette_1 text
@@ -191,16 +167,12 @@ CREATE TABLE tx_styleguide_elements_slugs (
 CREATE TABLE tx_styleguide_elements_rte_flex_1_inline_1_child (
     parentid int(11) DEFAULT '0' NOT NULL,
     parenttable text,
-
-    rte_1 text
 );
 
 
 CREATE TABLE tx_styleguide_elements_rte_inline_1_child (
     parentid int(11) DEFAULT '0' NOT NULL,
     parenttable text,
-
-    rte_1 text
 );
 
 
@@ -280,8 +252,6 @@ CREATE TABLE tx_styleguide_elements_select_flex_1_multiplesidebyside_2_mm (
 
 
 CREATE TABLE tx_styleguide_elements_t3editor (
-    t3editor_1 text,
-    t3editor_2 text,
     t3editor_reload_1 int(11) DEFAULT '0' NOT NULL,
     t3editor_inline_1 text,
 );
@@ -290,16 +260,12 @@ CREATE TABLE tx_styleguide_elements_t3editor (
 CREATE TABLE tx_styleguide_elements_t3editor_flex_1_inline_1_child (
     parentid int(11) DEFAULT '0' NOT NULL,
     parenttable text,
-
-    t3editor_1 text
 );
 
 
 CREATE TABLE tx_styleguide_elements_t3editor_inline_1_child (
     parentid int(11) DEFAULT '0' NOT NULL,
     parenttable text,
-
-    t3editor_1 text
 );
 
 
@@ -344,9 +310,7 @@ CREATE TABLE tx_styleguide_inline_1n_inline_2_child (
     parenttable text,
 
     input_1 text,
-    rte_1 text,
     select_tree_1 text,
-    t3editor_1 text
 );
 
 CREATE TABLE tx_styleguide_inline_1nnol10n (
@@ -393,9 +357,7 @@ CREATE TABLE tx_styleguide_inline_expand_inline_1_child (
     parenttable text,
 
     dummy_1 text,
-    rte_1 text,
     select_tree_1 text,
-    t3editor_1 text
 );
 
 
@@ -568,8 +530,6 @@ CREATE TABLE tx_styleguide_required (
 
     link_1 text,
 
-    text_1 text,
-
     select_1 text,
     select_2 text,
     select_3 text,
@@ -623,8 +583,6 @@ CREATE TABLE tx_styleguide_required_inline_3_child (
 CREATE TABLE tx_styleguide_required_rte_2_child (
     parentid int(11) DEFAULT '0' NOT NULL,
     parenttable text,
-
-    rte_1 text
 );
 
 
@@ -637,7 +595,6 @@ CREATE TABLE tx_styleguide_type (
     record_type text,
     input_1 text,
     color_1 text,
-    text_1 text
 );
 
 
@@ -645,7 +602,6 @@ CREATE TABLE tx_styleguide_typeforeign (
     foreign_table int(11) DEFAULT '0' NOT NULL,
     input_1 text,
     color_1 text,
-    text_1 text
 );
 
 
@@ -653,8 +609,6 @@ CREATE TABLE tx_styleguide_valuesdefault (
     input_1 text,
 
     number_1 int(11) DEFAULT '0' NOT NULL,
-
-    text_1 text,
 
     radio_1 int(11) DEFAULT '0' NOT NULL,
     radio_2 text,
@@ -671,11 +625,6 @@ CREATE TABLE tx_styleguide_l10nreadonly (
     radio int(11) DEFAULT '0' NOT NULL,
     none text,
     language int(11) DEFAULT '0' NOT NULL,
-    text text,
-    text_rte text,
-    text_belayoutwizard text,
-    text_t3editor text,
-    text_table text,
     select_single text,
     select_single_box text,
     select_checkbox text,


### PR DESCRIPTION
We're adding core code to add default sql definitions derived from TCA. Fields of type=text do not need to be set anymore.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81127

Releases: main
Related: https://forge.typo3.org/issues/101986