### PR TITLE
[TASK] Remove all type=password sql field definitions

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -99,15 +99,6 @@ CREATE TABLE tx_styleguide_elements_basic (
     link_4 text,
     link_5 text,
 
-    password_1 varchar(255) DEFAULT '' NOT NULL,
-    password_2 varchar(255) DEFAULT '' NOT NULL,
-    password_3 varchar(255) DEFAULT '' NOT NULL,
-    password_4 varchar(255) DEFAULT '' NOT NULL,
-    password_5 varchar(255) DEFAULT '' NOT NULL,
-    password_6 varchar(255) DEFAULT '' NOT NULL,
-    password_7 varchar(255) DEFAULT '' NOT NULL,
-    password_8 varchar(255) DEFAULT NULL,
-
     color_1 text,
     color_2 text,
     color_3 text,


### PR DESCRIPTION
We're adding core code to add default sql definitions derived from TCA. Fields of type=password do not need to be set anymore.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81362

Releases: main
Related: https://forge.typo3.org/issues/102106