### PR TITLE
[TASK] Remove all type=radio sql field definitions

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -107,13 +107,6 @@ CREATE TABLE tx_styleguide_elements_basic (
 
     text_12 text,
 
-    radio_1 int(11) DEFAULT '0' NOT NULL,
-    radio_2 int(11) DEFAULT '0' NOT NULL,
-    radio_3 int(11) DEFAULT '0' NOT NULL,
-    radio_4 text,
-    radio_5 int(11) DEFAULT '0' NOT NULL,
-    radio_6 int(11) DEFAULT '0' NOT NULL,
-
     none_1 text,
     none_2 text,
     none_3 text,
@@ -575,10 +568,6 @@ CREATE TABLE tx_styleguide_valuesdefault (
 
     number_1 int(11) DEFAULT '0' NOT NULL,
 
-    radio_1 int(11) DEFAULT '0' NOT NULL,
-    radio_2 text,
-    radio_3 text,
-
     select_1 text,
     select_2 text
 );
@@ -586,7 +575,6 @@ CREATE TABLE tx_styleguide_valuesdefault (
 CREATE TABLE tx_styleguide_l10nreadonly (
     input text,
     link text,
-    radio int(11) DEFAULT '0' NOT NULL,
     none text,
     language int(11) DEFAULT '0' NOT NULL,
     select_single text,


### PR DESCRIPTION
We're adding core code to add default sql definitions derived from TCA. Fields of type=radio do not need to be set anymore.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81426

Releases: main
Related: https://forge.typo3.org/issues/102163