### PR TITLE
[TASK] Remove all type=link sql field definitions

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -92,12 +92,6 @@ CREATE TABLE tx_styleguide_elements_basic (
     input_42 text,
     input_43 text,
 
-    link_1 text,
-    link_2 text,
-    link_3 text,
-    link_4 text,
-    link_5 text,
-
     number_1 text,
     number_2 int(11) DEFAULT '0' NOT NULL,
     number_3 int(11) DEFAULT '0' NOT NULL,
@@ -495,8 +489,6 @@ CREATE TABLE tx_styleguide_required (
 
     input_1 text,
 
-    link_1 text,
-
     select_1 text,
     select_2 text,
     select_3 text,
@@ -585,7 +577,6 @@ CREATE TABLE tx_styleguide_valuesdefault (
 
 CREATE TABLE tx_styleguide_l10nreadonly (
     input text,
-    link text,
     radio int(11) DEFAULT '0' NOT NULL,
     none text,
     language int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
We're adding core code to add default sql definitions derived from TCA. Fields of type=radio do not need to be set anymore.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81427

Releases: main
Related: https://forge.typo3.org/issues/102168