### PR TITLE
[FEATURE] TCA inline foreign_match_fields example

### DIFF
--- a/Classes/TcaDataGenerator/FieldGenerator/TypeInline1n.php
+++ b/Classes/TcaDataGenerator/FieldGenerator/TypeInline1n.php
@@ -73,6 +73,9 @@ class TypeInline1n extends AbstractFieldGenerator implements FieldGeneratorInter
             'parentid' => $data['fieldValues']['uid'],
             'parenttable' => $data['tableName'],
         ];
+        if ($data['fieldConfig']['config']['foreign_match_fields']['role'] ?? false) {
+            $childFieldValues['role'] = $data['fieldConfig']['config']['foreign_match_fields']['role'];
+        }
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($childTable);
         $connection->insert($childTable, $childFieldValues);
         $childFieldValues['uid'] = (int)$connection->lastInsertId($childTable);

--- a/Configuration/TCA/tx_styleguide_inline_1nreusabletable.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nreusabletable.php
@@ -1,0 +1,117 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Form engine - inline 1:n foreign_match_fields',
+        'label' => 'uid',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'iconfile' => 'EXT:styleguide/Resources/Public/Icons/tx_styleguide.svg',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+
+    'columns' => [
+        'hidden' => [
+            'config' => [
+                'type' => 'check',
+                'items' => [
+                    ['label' => 'Disable'],
+                ],
+            ],
+        ],
+        'sys_language_uid' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => '', 'value' => 0],
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable',
+                'foreign_table_where' => 'AND {#tx_styleguide_inline_1nreusabletable}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nreusabletable}.{#sys_language_uid} IN (-1,0)',
+                'default' => 0,
+            ],
+        ],
+        'l10n_source' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation source',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => '', 'value' => 0],
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable',
+                'foreign_table_where' => 'AND {#tx_styleguide_inline_1nreusabletable}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nreusabletable}.{#uid}!=###THIS_UID###',
+                'default' => 0,
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+
+        'inline_1' => [
+            'label' => 'inline_1 description',
+            'description' => 'field description',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable_child',
+                'foreign_field' => 'parentid',
+                'foreign_table_field' => 'parenttable',
+                'foreign_match_fields' => [
+                    'role' => 'inline_1',
+                ],
+            ],
+        ],
+        'inline_2' => [
+            'label' => 'inline_2',
+            'config' => [
+                'type' => 'inline',
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable_child',
+                'foreign_field' => 'parentid',
+                'foreign_table_field' => 'parenttable',
+                'foreign_match_fields' => [
+                    'role' => 'inline_2',
+                ],
+            ],
+        ],
+    ],
+
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;inline_1,
+                    inline_1,
+                --div--;inline_2,
+                    inline_2,
+                --div--;meta,
+                    disable, sys_language_uid, l10n_parent, l10n_source,
+
+            ',
+        ],
+    ],
+
+];

--- a/Configuration/TCA/tx_styleguide_inline_1nreusabletable_child.php
+++ b/Configuration/TCA/tx_styleguide_inline_1nreusabletable_child.php
@@ -1,0 +1,92 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Form engine - inline 1:n foreign field child, which is reused in multiple fields',
+        'label' => 'email',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'sortby' => 'sorting',
+        'iconfile' => 'EXT:styleguide/Resources/Public/Icons/tx_styleguide.svg',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'enablecolumns' => [
+            'disabled' => 'disable',
+        ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+
+    'columns' => [
+
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+        'disable' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.disable',
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
+        'sys_language_uid' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => '', 'value' => 0],
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable_child',
+                'foreign_table_where' => 'AND {#tx_styleguide_inline_1nreusabletable_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nreusabletable_child}.{#sys_language_uid} IN (-1,0)',
+                'default' => 0,
+            ],
+        ],
+        'l10n_source' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'Translation source',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => '', 'value' => 0],
+                ],
+                'foreign_table' => 'tx_styleguide_inline_1nreusabletable_child',
+                'foreign_table_where' => 'AND {#tx_styleguide_inline_1nreusabletable_child}.{#pid}=###CURRENT_PID### AND {#tx_styleguide_inline_1nreusabletable_child}.{#uid}!=###THIS_UID###',
+                'default' => 0,
+            ],
+        ],
+        'email' => [
+            'label' => 'email',
+            'config' => [
+                'type' => 'email',
+            ],
+        ],
+        'role' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;General, email,
+                --div--;meta, disable, sys_language_uid, l10n_parent, l10n_source,
+            ',
+        ],
+    ],
+];

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -234,6 +234,10 @@ CREATE TABLE tx_styleguide_inline_1n_inline_2_child (
     select_tree_1 text,
 );
 
+CREATE TABLE tx_styleguide_inline_1nreusabletable_child (
+    role text
+);
+
 CREATE TABLE tx_styleguide_inline_1nnol10n_child (
     input_1 text
 );


### PR DESCRIPTION
An example for foreign_match_fields is added, which demonstrates how to reuse a child table in multiple type inline fields.

Releases: main